### PR TITLE
create public barbershop landing page /[slug]

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,8 @@
 - /onboarding/step-2 → servicios (opcional)
 - /onboarding/step-3 → barberos (opcional)
 - /dashboard → panel principal del dueño (protegida)
+- /[slug] → landing pública de la barbería (no requiere auth)
+- /[slug]/reservar → reserva de turno (próxima feature, no implementada aún)
 
 ## Decisiones técnicas importantes
 - profiles.tenantId es nullable — se asigna en Step 1 del onboarding
@@ -29,9 +31,17 @@
 - Drizzle bypassa RLS — autorización manual en Server Actions via supabase.auth.getUser()
 - Middleware chequea user.app_metadata?.tenant_id (del JWT, sin query a DB)
 - Step 1 llama adminClient.auth.admin.updateUserById() + supabase.auth.refreshSession() para actualizar JWT antes del redirect
+- refreshSession() verifica el resultado y retorna error de form si falla, nunca redirige con JWT viejo
 - Formularios usan useActionState de React 19
 - Servicios y barberos se serializan como JSON en hidden inputs
 - Diseño Mobile-First siempre — Tailwind breakpoints md: y lg: para desktop
+- Landing usa RSC puro — fetch en servidor, nada sensible al cliente
+- Barberos usa LEFT JOIN con profiles para obtener avatarUrl (profileId nullable)
+- No hay relations() definidas en Drizzle — queries manuales
+- openingHours casteado como OpeningHours | null sin validación runtime (aceptable, dato escrito por nuestro onboarding)
+- Google Maps removido intencionalmente — dirección se muestra como texto plano hasta tener ciudad/país en el schema
+- Doble query de tenant entre generateMetadata y page (deuda conocida, solución futura: React.cache())
+- Sin caching en landing (deuda conocida, solución futura: unstable_cache)
 
 ## Estado de Supabase
 - Bucket "logos" creado (público)
@@ -45,9 +55,10 @@
 - ✅ Autenticación (register + login + logout)
 - ✅ Onboarding wizard 3 pasos
 - ✅ Dashboard principal con botón "Ver mi landing"
+- ✅ Landing pública /[slug] (7 secciones + 404 personalizada + SEO dinámico)
 
 ## Próximas features
+- [ ] Reserva de turno /[slug]/reservar ← EN CURSO
 - [ ] Sistema de turnos (calendario en dashboard)
-- [ ] Landing pública /[slug] + reserva de turno
 - [ ] CRM de clientes
 - [ ] Notificaciones (WhatsApp/Twilio)

--- a/app/[slug]/not-found.tsx
+++ b/app/[slug]/not-found.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { Scissors } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 flex flex-col items-center justify-center px-4 text-center">
+      <Scissors className="w-16 h-16 text-zinc-700 mx-auto mb-6" />
+      <h1 className="text-6xl font-extrabold text-amber-500 mb-4">404</h1>
+      <h2 className="text-2xl font-bold text-zinc-100 mb-3">
+        Esta barbería no existe
+      </h2>
+      <p className="text-zinc-400 mb-8 max-w-sm">
+        El link que seguiste no corresponde a ninguna barbería registrada en
+        BarberSaaS.
+      </p>
+      <Link
+        href="/"
+        className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-zinc-950 font-bold py-3 px-6 rounded-xl transition-colors"
+      >
+        Volver al inicio
+      </Link>
+      <p className="mt-12 text-zinc-600 text-sm">
+        Powered by <span className="text-amber-500/70">BarberSaaS</span>
+      </p>
+    </div>
+  );
+}

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,49 +1,359 @@
 import { notFound } from "next/navigation";
-import { eq } from "drizzle-orm";
-import { db } from "@/lib/db";
-import { tenants } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import Image from "next/image";
+import Link from "next/link";
+import { MapPin, Clock } from "lucide-react";
+import type { Metadata } from "next";
 
-interface TenantLandingPageProps {
+import { db } from "@/lib/db";
+import { tenants, barbers, services, profiles } from "@/lib/db/schema";
+import FaqAccordion from "@/components/landing/faq-accordion";
+
+interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
-export default async function TenantLandingPage({
-  params,
-}: TenantLandingPageProps) {
-  const { slug } = await params;
+type DaySchedule = { open: string; close: string };
+type OpeningHours = Partial<Record<string, DaySchedule>>;
 
-  const tenant = await db.query.tenants.findFirst({
-    where: eq(tenants.slug, slug),
-  });
+const DAYS = [
+  { key: "monday", label: "Lunes" },
+  { key: "tuesday", label: "Martes" },
+  { key: "wednesday", label: "Miércoles" },
+  { key: "thursday", label: "Jueves" },
+  { key: "friday", label: "Viernes" },
+  { key: "saturday", label: "Sábado" },
+  { key: "sunday", label: "Domingo" },
+] as const;
 
-  if (!tenant) {
-    notFound();
-  }
-
-  return (
-    <main className="min-h-screen">
-      <header className="p-6">
-        <h1 className="text-3xl font-bold">{tenant.name}</h1>
-        {tenant.address && (
-          <p className="text-muted-foreground">{tenant.address}</p>
-        )}
-      </header>
-      {/* TODO: Servicios, barberos disponibles, botón de reserva */}
-    </main>
-  );
+function formatPrice(price: string) {
+  return new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    maximumFractionDigits: 0,
+  }).format(Number(price));
 }
 
-export async function generateMetadata({ params }: TenantLandingPageProps) {
+function formatDuration(minutes: number) {
+  if (minutes < 60) return `${minutes} min`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h} h ${m} min` : `${h} h`;
+}
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.slug, slug),
+  });
+  if (!tenant) return {};
+  return {
+    title: `${tenant.name} | BarberSaaS`,
+    description: tenant.address
+      ? `Reservá tu turno en ${tenant.name}. ${tenant.address}`
+      : `Reservá tu turno en ${tenant.name}`,
+  };
+}
+
+export default async function TenantLandingPage({ params }: PageProps) {
   const { slug } = await params;
 
   const tenant = await db.query.tenants.findFirst({
     where: eq(tenants.slug, slug),
   });
 
-  if (!tenant) return {};
+  if (!tenant) notFound();
 
-  return {
-    title: tenant.name,
-    description: `Reservá tu turno en ${tenant.name}`,
-  };
+  const [barberList, serviceList] = await Promise.all([
+    db
+      .select({
+        id: barbers.id,
+        displayName: barbers.displayName,
+        bio: barbers.bio,
+        avatarUrl: profiles.avatarUrl,
+      })
+      .from(barbers)
+      .leftJoin(profiles, eq(barbers.profileId, profiles.id))
+      .where(and(eq(barbers.tenantId, tenant.id), eq(barbers.isActive, true))),
+    db
+      .select()
+      .from(services)
+      .where(
+        and(eq(services.tenantId, tenant.id), eq(services.isActive, true))
+      ),
+  ]);
+
+  const hours = tenant.openingHours as OpeningHours | null;
+  const reserveUrl = `/${slug}/reservar`;
+
+  const navLinks = [
+    ...(serviceList.length > 0
+      ? [{ href: "#servicios", label: "Servicios" }]
+      : []),
+    ...(barberList.length > 0
+      ? [{ href: "#barberos", label: "Barberos" }]
+      : []),
+    ...(tenant.address ? [{ href: "#ubicacion", label: "Ubicación" }] : []),
+    ...(hours ? [{ href: "#horarios", label: "Horarios" }] : []),
+    { href: "#faq", label: "FAQ" },
+  ];
+
+  return (
+    <>
+      {/* Mobile floating CTA */}
+      <div className="fixed bottom-0 left-0 right-0 z-50 md:hidden p-4 bg-zinc-950/95 backdrop-blur-sm border-t border-zinc-800">
+        <Link
+          href={reserveUrl}
+          className="block w-full text-center bg-amber-500 hover:bg-amber-400 text-zinc-950 font-bold py-3 px-6 rounded-xl transition-colors"
+        >
+          Reservar turno
+        </Link>
+      </div>
+
+      <div className="min-h-screen bg-zinc-950 text-zinc-100">
+        {/* Header */}
+        <header className="sticky top-0 z-40 bg-zinc-950/90 backdrop-blur-sm border-b border-zinc-800">
+          <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {tenant.logoUrl ? (
+                <Image
+                  src={tenant.logoUrl}
+                  alt={`Logo de ${tenant.name}`}
+                  width={40}
+                  height={40}
+                  className="rounded-full object-cover"
+                />
+              ) : (
+                <div className="w-10 h-10 rounded-full bg-amber-500 flex items-center justify-center text-zinc-950 font-bold text-sm flex-shrink-0">
+                  {getInitials(tenant.name)}
+                </div>
+              )}
+              <span className="font-bold text-lg">{tenant.name}</span>
+            </div>
+
+            {/* Desktop nav */}
+            <nav className="hidden md:flex items-center gap-6">
+              {navLinks.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className="text-sm text-zinc-400 hover:text-zinc-100 transition-colors"
+                >
+                  {link.label}
+                </a>
+              ))}
+              <Link
+                href={reserveUrl}
+                className="bg-amber-500 hover:bg-amber-400 text-zinc-950 font-bold py-2 px-4 rounded-lg text-sm transition-colors"
+              >
+                Reservar turno
+              </Link>
+            </nav>
+          </div>
+        </header>
+
+        <main>
+          {/* Hero */}
+          <section
+            id="inicio"
+            className="relative py-24 px-4 text-center overflow-hidden"
+          >
+            <div className="absolute inset-0 bg-gradient-to-b from-amber-950/20 to-transparent pointer-events-none" />
+            <div className="relative max-w-3xl mx-auto">
+              {tenant.logoUrl && (
+                <div className="flex justify-center mb-6">
+                  <Image
+                    src={tenant.logoUrl}
+                    alt={`Logo de ${tenant.name}`}
+                    width={100}
+                    height={100}
+                    className="rounded-full object-cover border-4 border-amber-500/30"
+                  />
+                </div>
+              )}
+              <h1 className="text-5xl md:text-6xl font-extrabold mb-4 tracking-tight">
+                {tenant.name}
+              </h1>
+              {tenant.address && (
+                <p className="inline-flex items-center gap-2 text-zinc-400 mb-8">
+                  <MapPin className="w-4 h-4" />
+                  {tenant.address}
+                </p>
+              )}
+              <div className="hidden md:flex justify-center mt-2">
+                <Link
+                  href={reserveUrl}
+                  className="bg-amber-500 hover:bg-amber-400 text-zinc-950 font-bold py-3 px-8 rounded-xl text-lg transition-colors"
+                >
+                  Reservar turno
+                </Link>
+              </div>
+            </div>
+          </section>
+
+          {/* Servicios */}
+          {serviceList.length > 0 && (
+            <section id="servicios" className="py-16 px-4">
+              <div className="max-w-5xl mx-auto">
+                <h2 className="text-3xl font-bold text-amber-400 mb-8">
+                  Servicios
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {serviceList.map((service) => (
+                    <div
+                      key={service.id}
+                      className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 hover:border-zinc-700 transition-colors"
+                    >
+                      <h3 className="font-semibold text-zinc-100 text-lg">
+                        {service.name}
+                      </h3>
+                      <div className="flex items-center justify-between mt-3">
+                        <span className="text-zinc-500 text-sm flex items-center gap-1.5">
+                          <Clock className="w-4 h-4" />
+                          {formatDuration(service.durationMinutes)}
+                        </span>
+                        <span className="text-amber-400 font-bold text-lg">
+                          {formatPrice(service.price)}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* Barberos */}
+          {barberList.length > 0 && (
+            <section id="barberos" className="py-16 px-4 bg-zinc-900/50">
+              <div className="max-w-5xl mx-auto">
+                <h2 className="text-3xl font-bold text-amber-400 mb-8">
+                  Nuestros Barberos
+                </h2>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+                  {barberList.map((barber) => (
+                    <div
+                      key={barber.id}
+                      className="flex flex-col items-center text-center"
+                    >
+                      {barber.avatarUrl ? (
+                        <div className="relative w-20 h-20 rounded-full overflow-hidden mb-3 ring-2 ring-zinc-700">
+                          <Image
+                            src={barber.avatarUrl}
+                            alt={barber.displayName}
+                            fill
+                            sizes="80px"
+                            className="object-cover"
+                          />
+                        </div>
+                      ) : (
+                        <div className="w-20 h-20 rounded-full bg-zinc-800 border-2 border-zinc-700 flex items-center justify-center mb-3 text-xl font-bold text-amber-400">
+                          {getInitials(barber.displayName)}
+                        </div>
+                      )}
+                      <span className="font-medium text-zinc-100">
+                        {barber.displayName}
+                      </span>
+                      {barber.bio && (
+                        <p className="text-xs text-zinc-500 mt-1 line-clamp-2">
+                          {barber.bio}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* Ubicación */}
+          {tenant.address && (
+            <section id="ubicacion" className="py-16 px-4">
+              <div className="max-w-5xl mx-auto">
+                <h2 className="text-3xl font-bold text-amber-400 mb-8">
+                  Ubicación
+                </h2>
+                <div className="flex items-start gap-3">
+                  <MapPin className="w-5 h-5 text-amber-400 mt-0.5 flex-shrink-0" />
+                  <p className="text-zinc-300 text-lg">{tenant.address}</p>
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* Horarios */}
+          {hours && (
+            <section id="horarios" className="py-16 px-4 bg-zinc-900/50">
+              <div className="max-w-5xl mx-auto">
+                <h2 className="text-3xl font-bold text-amber-400 mb-8">
+                  Horarios
+                </h2>
+                <div className="max-w-xs">
+                  {DAYS.map(({ key, label }) => {
+                    const day = hours[key];
+                    return (
+                      <div
+                        key={key}
+                        className="flex justify-between py-3 border-b border-zinc-800 last:border-0"
+                      >
+                        <span className="text-zinc-300 font-medium">
+                          {label}
+                        </span>
+                        <span
+                          className={day ? "text-zinc-100" : "text-zinc-600"}
+                        >
+                          {day ? `${day.open} – ${day.close}` : "Cerrado"}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* FAQ */}
+          <section id="faq" className="py-16 px-4">
+            <div className="max-w-3xl mx-auto">
+              <h2 className="text-3xl font-bold text-amber-400 mb-8">
+                Preguntas frecuentes
+              </h2>
+              <FaqAccordion />
+            </div>
+          </section>
+        </main>
+
+        {/* Footer */}
+        <footer className="border-t border-zinc-800 py-10 px-4">
+          <div className="max-w-5xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4 text-center md:text-left">
+            <div>
+              <p className="font-bold text-zinc-100">{tenant.name}</p>
+              {tenant.address && (
+                <p className="text-zinc-500 text-sm mt-1">{tenant.address}</p>
+              )}
+            </div>
+            <p className="text-zinc-600 text-sm">
+              Powered by{" "}
+              <span className="text-amber-500 font-medium">BarberSaaS</span>
+            </p>
+          </div>
+        </footer>
+
+        {/* Spacer so mobile floating button doesn't cover content */}
+        <div className="h-24 md:hidden" />
+      </div>
+    </>
+  );
 }

--- a/components/landing/faq-accordion.tsx
+++ b/components/landing/faq-accordion.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+const FAQ_ITEMS = [
+  {
+    question: "¿Cómo cancelo un turno?",
+    answer:
+      "Podés cancelar tu turno hasta 2 horas antes del horario reservado. Contactanos por WhatsApp o utilizá el link que recibiste en la confirmación de tu reserva.",
+  },
+  {
+    question: "¿Cuánto tiempo de tolerancia hay si llego tarde?",
+    answer:
+      "Contamos con 10 minutos de tolerancia. Pasado ese tiempo, el turno puede ser reasignado a otro cliente.",
+  },
+  {
+    question: "¿Qué métodos de pago aceptan?",
+    answer:
+      "Aceptamos efectivo y transferencia bancaria. Para más información sobre otros métodos de pago, consultá directamente con la barbería.",
+  },
+  {
+    question: "¿Puedo elegir mi barbero?",
+    answer:
+      "¡Sí! Al momento de reservar tu turno podés seleccionar al barbero de tu preferencia, sujeto a su disponibilidad.",
+  },
+];
+
+export default function FaqAccordion() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <div className="space-y-2">
+      {FAQ_ITEMS.map((item, index) => (
+        <div
+          key={index}
+          className="border border-zinc-800 rounded-xl overflow-hidden"
+        >
+          <button
+            className="w-full flex items-center justify-between p-5 text-left hover:bg-zinc-900/50 transition-colors"
+            onClick={() => setOpenIndex(openIndex === index ? null : index)}
+            aria-expanded={openIndex === index}
+          >
+            <span className="font-medium text-zinc-100 pr-4">
+              {item.question}
+            </span>
+            <ChevronDown
+              className={`w-5 h-5 text-zinc-400 flex-shrink-0 transition-transform duration-200 ${
+                openIndex === index ? "rotate-180" : ""
+              }`}
+            />
+          </button>
+          {openIndex === index && (
+            <div className="px-5 pb-5 text-zinc-400 text-sm leading-relaxed">
+              {item.answer}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,8 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-// Matches /{slug} and /{slug}/book — public tenant routes
-const SLUG_PATTERN = /^\/[a-z0-9-]+(?:\/book(?:\/.*)?)?$/;
+// Matches /{slug} and /{slug}/reservar — public tenant routes
+const SLUG_PATTERN = /^\/[a-z0-9-]+(?:\/reservar(?:\/.*)?)?$/;
 
 const AUTH_ROUTES = ["/login", "/register"];
 
@@ -47,7 +47,7 @@ export async function middleware(request: NextRequest) {
   const isOnboarding = pathname.startsWith("/onboarding");
   const isDashboard = pathname.startsWith("/dashboard");
 
-  // Tenant public routes: /{slug} and /{slug}/book
+  // Tenant public routes: /{slug} and /{slug}/reservar
   // Must be checked AFTER known system routes to avoid conflicts (e.g. /dashboard)
   const isTenantRoute =
     !isAuthRoute && !isOnboarding && !isDashboard && SLUG_PATTERN.test(pathname);

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## feat: landing pública /[slug]

### Qué incluye
- Landing pública por barbería accesible en /[slug] sin autenticación
- 7 secciones: Hero, Servicios, Barberos, Ubicación, Horarios, FAQ, Footer
- Header sticky con navbar en desktop y botón flotante en mobile
- 404 personalizada cuando el slug no existe
- SEO dinámico con metadata del tenant
- RSC puro — todo el fetch ocurre en servidor
- next/image configurado para Supabase Storage

### Decisiones
- Dirección mostrada como texto plano (Google Maps removido hasta 
  tener ciudad/país en el schema)
- FAQ con 4 preguntas estándar hardcodeadas (personalización post-lanzamiento)
- LEFT JOIN de barberos con profiles para obtener avatarUrl

### Issues trackeados
#7  #8  #9  #10 