### PR TITLE
fix: add reserved slugs validation and opening hours time order check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# BarberSaaS — CLAUDE.md
+
+> El estado del proyecto (rutas, features, decisiones técnicas, deuda conocida) está en `context.md`, que se provee al inicio de cada sesión. Este archivo contiene solo las reglas permanentes.
+
+---
+
+## Código
+
+- TypeScript estricto — sin `any`, sin `as unknown as Type`
+- Server Components por defecto — `"use client"` solo cuando sea necesario
+- Queries de DB **siempre via Drizzle** — nunca cliente raw de Supabase
+- Validación con **Zod** en Server Actions y en cliente
+- Formularios con `useActionState` de React 19
+- Ante dudas de scope: preguntar antes de implementar
+
+## Seguridad / multi-tenancy
+
+- Toda query filtra por `tenant_id`
+- Drizzle bypassa RLS — autorización manual via `supabase.auth.getUser()` en Server Actions
+- Middleware usa `user.app_metadata?.tenant_id` del JWT, sin query a DB
+
+## UI
+
+- **Mobile-first siempre** — breakpoints `md:` y `lg:` para desktop
+- **Dark mode** por defecto
+- Componentes base: **shadcn/ui** — no reinventar primitivos, no hackear sus estilos
+- Íconos: **Lucide** únicamente
+- Colores como CSS variables en `globals.css`
+- Estética: premium, masculino, moderno — sin gradientes purple/azul genéricos de SaaS
+
+## No hacer (sin discutir primero)
+
+- Resolver deuda técnica no asignada
+- Agregar features fuera del scope de la sesión
+- Cambiar decisiones de stack (auth, ORM, etc.)
+- Instalar dependencias nuevas sin confirmar

--- a/lib/validations/onboarding.ts
+++ b/lib/validations/onboarding.ts
@@ -1,16 +1,38 @@
 import { z } from "zod";
 
-const daySchedule = z.object({
-  closed: z.boolean(),
-  open: z
-    .string()
-    .regex(/^\d{2}:\d{2}$/)
-    .optional(),
-  close: z
-    .string()
-    .regex(/^\d{2}:\d{2}$/)
-    .optional(),
-});
+const RESERVED_SLUGS = [
+  "api",
+  "login",
+  "register",
+  "dashboard",
+  "onboarding",
+  "reservar",
+  "not-found",
+  "404",
+  "admin",
+  "static",
+  "_next",
+];
+
+const daySchedule = z
+  .object({
+    closed: z.boolean(),
+    open: z
+      .string()
+      .regex(/^\d{2}:\d{2}$/)
+      .optional(),
+    close: z
+      .string()
+      .regex(/^\d{2}:\d{2}$/)
+      .optional(),
+  })
+  .refine(
+    (day) => {
+      if (day.closed || !day.open || !day.close) return true;
+      return day.open < day.close;
+    },
+    { message: "El horario de apertura debe ser anterior al de cierre" }
+  );
 
 export const DAYS = [
   "monday",
@@ -43,7 +65,8 @@ export const step1Schema = z.object({
     .string()
     .min(2, "Mínimo 2 caracteres")
     .max(50, "Máximo 50 caracteres")
-    .regex(/^[a-z0-9-]+$/, "Solo minúsculas, números y guiones"),
+    .regex(/^[a-z0-9-]+$/, "Solo minúsculas, números y guiones")
+    .refine((val) => !RESERVED_SLUGS.includes(val), "Este nombre no está disponible"),
   address: z.string().max(200).optional(),
   openingHours: z.object({
     monday: daySchedule,


### PR DESCRIPTION
## fix: validaciones en onboarding step 1

### Qué incluye
- Slugs reservados: array RESERVED_SLUGS con palabras del sistema 
  (api, login, dashboard, etc.) — rechaza con "Este nombre no está disponible"
- Horarios: validación open < close via comparación lexicográfica HH:MM,
  ignorando días cerrados o con campos vacíos

### Issues cerrados
Closes #2
Closes #3