### PR TITLE
fix: add server-side validation for logo upload size and MIME type

### DIFF
--- a/actions/onboarding.ts
+++ b/actions/onboarding.ts
@@ -77,6 +77,12 @@ export async function saveStep1(
   let logoUrl: string | undefined;
   const logoFile = formData.get("logo") as File | null;
   if (logoFile && logoFile.size > 0) {
+    if (logoFile.size > 5 * 1024 * 1024) {
+      return { error: { logo: ["El logo no puede superar los 5MB"] } };
+    }
+    if (!logoFile.type.startsWith("image/")) {
+      return { error: { logo: ["El archivo debe ser una imagen"] } };
+    }
     const { data: uploadData, error: uploadError } = await supabase.storage
       .from("logos")
       .upload(`${slug}/${Date.now()}`, logoFile, { upsert: true });


### PR DESCRIPTION
## fix: validación server-side en upload de logo

### Qué incluye
- Tamaño máximo 5MB validado en server action antes del upload
- Tipo MIME validado (debe comenzar con "image/") antes del upload
- Errores retornados en el campo logo consistente con el resto del action

### Issues cerrados
Closes #4