### PR TITLE
fix: prevent duplicate services and barbers on onboarding re-submit

### DIFF
--- a/actions/onboarding.ts
+++ b/actions/onboarding.ts
@@ -159,16 +159,19 @@ export async function saveStep2(
     (s) => s.name.trim().length > 0,
   );
 
-  if (validServices.length > 0) {
-    await db.insert(services).values(
-      validServices.map((s) => ({
-        tenantId,
-        name: s.name.trim(),
-        durationMinutes: s.durationMinutes,
-        price: String(s.price),
-      })),
-    );
-  }
+  await db.transaction(async (tx) => {
+    await tx.delete(services).where(eq(services.tenantId, tenantId));
+    if (validServices.length > 0) {
+      await tx.insert(services).values(
+        validServices.map((s) => ({
+          tenantId,
+          name: s.name.trim(),
+          durationMinutes: s.durationMinutes,
+          price: String(s.price),
+        })),
+      );
+    }
+  });
 
   redirect("/onboarding/step-3");
 }
@@ -233,9 +236,12 @@ export async function saveStep3(
     });
   }
 
-  if (toInsert.length > 0) {
-    await db.insert(barbers).values(toInsert);
-  }
+  await db.transaction(async (tx) => {
+    await tx.delete(barbers).where(eq(barbers.tenantId, tenantId));
+    if (toInsert.length > 0) {
+      await tx.insert(barbers).values(toInsert);
+    }
+  });
 
   redirect("/dashboard");
 }


### PR DESCRIPTION
## fix: evitar duplicados al re-enviar steps 2 y 3 del onboarding

### Qué incluye
- saveStep2 y saveStep3 ahora usan una transacción que borra 
  registros existentes antes de insertar los nuevos
- Evita duplicados si el usuario re-envía el form desde el dashboard
- El delete filtra por tenant_id — sin riesgo cross-tenant

### Issues cerrados
Closes #5
