### PR TITLE
feat: appointment booking wizard with client recognition and confirma…

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,13 +23,15 @@
 - /onboarding/step-3 → barberos (opcional)
 - /dashboard → panel principal del dueño (protegida)
 - /[slug] → landing pública de la barbería (no requiere auth)
-- /[slug]/reservar → reserva de turno (próxima feature, no implementada aún)
+- /[slug]/reservar → wizard de reserva de 4 pasos (no requiere auth)
+- /[slug]/reservar/confirmacion → página de éxito con searchParams
 
 ## Decisiones técnicas importantes
 - profiles.tenantId es nullable — se asigna en Step 1 del onboarding
 - barbers.profileId es nullable — barberos pueden existir sin cuenta
 - Drizzle bypassa RLS — autorización manual en Server Actions via supabase.auth.getUser()
 - Middleware chequea user.app_metadata?.tenant_id (del JWT, sin query a DB)
+- Middleware excluye /[slug] y /[slug]/reservar de la protección de auth
 - Step 1 llama adminClient.auth.admin.updateUserById() + supabase.auth.refreshSession() para actualizar JWT antes del redirect
 - refreshSession() verifica el resultado y retorna error de form si falla, nunca redirige con JWT viejo
 - Formularios usan useActionState de React 19
@@ -38,10 +40,14 @@
 - Landing usa RSC puro — fetch en servidor, nada sensible al cliente
 - Barberos usa LEFT JOIN con profiles para obtener avatarUrl (profileId nullable)
 - No hay relations() definidas en Drizzle — queries manuales
-- openingHours casteado como OpeningHours | null sin validación runtime (aceptable, dato escrito por nuestro onboarding)
-- Google Maps removido intencionalmente — dirección se muestra como texto plano hasta tener ciudad/país en el schema
-- Doble query de tenant entre generateMetadata y page (deuda conocida, solución futura: React.cache())
-- Sin caching en landing (deuda conocida, solución futura: unstable_cache)
+- db.select() explícito en lugar de db.query relacional para evitar ambigüedad con displayName (camelCase vs snake_case)
+- openingHours casteado con Zod safeParse — si falla, se trata como null
+- Google Maps removido intencionalmente — dirección como texto plano hasta tener ciudad/país en el schema
+- tenant.phone puede ser null — WhatsApp usa wa.me/?text=... sin destinatario en ese caso
+- "Sin preferencia" en barbero se resuelve al primer barbero activo del tenant en getAvailableSlots y createAppointment
+- Conflict check fuera de la transacción — dentro solo van upsert de client e insert de appointment
+- visitCount se incrementa en cada booking por diseño
+- Confirmación recibe datos via searchParams, sin query a DB — guard redirige a /reservar si faltan params
 
 ## Estado de Supabase
 - Bucket "logos" creado (público)
@@ -56,9 +62,10 @@
 - ✅ Onboarding wizard 3 pasos
 - ✅ Dashboard principal con botón "Ver mi landing"
 - ✅ Landing pública /[slug] (7 secciones + 404 personalizada + SEO dinámico)
+- ✅ Wizard de reserva /[slug]/reservar (4 pasos + reconocimiento cliente recurrente)
 
 ## Próximas features
-- [ ] Reserva de turno /[slug]/reservar ← EN CURSO
-- [ ] Sistema de turnos (calendario en dashboard)
+- [ ] Sistema de turnos (calendario en dashboard) ← SIGUIENTE
 - [ ] CRM de clientes
 - [ ] Notificaciones (WhatsApp/Twilio)
+- [ ] Gestión de barberos y servicios en dashboard

--- a/actions/booking.ts
+++ b/actions/booking.ts
@@ -1,0 +1,371 @@
+"use server";
+
+import { eq, and, notInArray } from "drizzle-orm";
+import { redirect } from "next/navigation";
+import { db } from "@/lib/db";
+import {
+  tenants,
+  barbers,
+  services,
+  clients,
+  appointments,
+  blockedSlots,
+} from "@/lib/db/schema";
+import { bookingSchema } from "@/lib/validations/booking";
+import type { ActionState } from "@/actions/auth";
+
+type TimeInterval = { start: string; end: string };
+type BarberAvailability = Record<string, TimeInterval[]>;
+type OpeningHoursDay = { closed: boolean; open?: string; close?: string };
+type OpeningHoursMap = Record<string, OpeningHoursDay>;
+
+const WEEK_DAYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTime(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+function generateSlots(start: string, end: string, duration: number): string[] {
+  const slots: string[] = [];
+  let cur = timeToMinutes(start);
+  const endMins = timeToMinutes(end);
+  while (cur + duration <= endMins) {
+    slots.push(minutesToTime(cur));
+    cur += duration;
+  }
+  return slots;
+}
+
+function overlaps(
+  aStart: string,
+  aEnd: string,
+  bStart: string,
+  bEnd: string,
+): boolean {
+  return (
+    timeToMinutes(aStart) < timeToMinutes(bEnd) &&
+    timeToMinutes(aEnd) > timeToMinutes(bStart)
+  );
+}
+
+export async function lookupClient(
+  tenantId: string,
+  phone: string,
+): Promise<{
+  id: string;
+  name: string;
+  preferences: Record<string, string> | null;
+} | null> {
+  if (!phone || phone.length < 6) return null;
+  const found = await db.query.clients.findFirst({
+    where: and(eq(clients.tenantId, tenantId), eq(clients.phone, phone)),
+    columns: { id: true, name: true, preferences: true },
+  });
+  return found ?? null;
+}
+
+export async function getAvailableSlots(
+  tenantId: string,
+  barberId: string | null,
+  date: string,
+  durationMinutes: number,
+): Promise<string[]> {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return [];
+
+  const dateObj = new Date(`${date}T00:00:00`);
+  const dayKey = WEEK_DAYS[dateObj.getDay()];
+
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.id, tenantId),
+    columns: { openingHours: true },
+  });
+  if (!tenant) return [];
+
+  const openingHours = tenant.openingHours as OpeningHoursMap | null;
+  let baseSlots: string[] = [];
+
+  // For "sin preferencia" (barberId null), resolve to the first active barber
+  // so availability and conflict checks always operate on a real barber.
+  let effectiveBarberId: string;
+  if (barberId) {
+    effectiveBarberId = barberId;
+  } else {
+    const [firstBarber] = await db
+      .select({ id: barbers.id })
+      .from(barbers)
+      .where(and(eq(barbers.tenantId, tenantId), eq(barbers.isActive, true)))
+      .limit(1);
+    if (!firstBarber) return [];
+    effectiveBarberId = firstBarber.id;
+  }
+
+  const barber = await db.query.barbers.findFirst({
+    where: and(
+      eq(barbers.id, effectiveBarberId),
+      eq(barbers.tenantId, tenantId),
+      eq(barbers.isActive, true),
+    ),
+    columns: { availability: true },
+  });
+
+  const availability = barber?.availability as
+    | BarberAvailability
+    | null
+    | undefined;
+
+  if (availability?.[dayKey]) {
+    for (const interval of availability[dayKey]) {
+      baseSlots.push(
+        ...generateSlots(interval.start, interval.end, durationMinutes),
+      );
+    }
+  } else {
+    const day = openingHours?.[dayKey];
+    if (day && !day.closed && day.open && day.close) {
+      baseSlots = generateSlots(day.open, day.close, durationMinutes);
+    }
+  }
+
+  if (baseSlots.length === 0) return [];
+
+  // Filter out past times for today (with 30-min buffer)
+  const now = new Date();
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  const cutoffMinutes =
+    date === todayStr ? now.getHours() * 60 + now.getMinutes() + 30 : 0;
+
+  const [existingAppts, blocked] = await Promise.all([
+    db
+      .select({
+        startTime: appointments.startTime,
+        endTime: appointments.endTime,
+      })
+      .from(appointments)
+      .where(
+        and(
+          eq(appointments.tenantId, tenantId),
+          eq(appointments.barberId, effectiveBarberId),
+          eq(appointments.date, date),
+        ),
+      ),
+    db
+      .select({
+        startTime: blockedSlots.startTime,
+        endTime: blockedSlots.endTime,
+      })
+      .from(blockedSlots)
+      .where(
+        and(
+          eq(blockedSlots.tenantId, tenantId),
+          eq(blockedSlots.barberId, effectiveBarberId),
+          eq(blockedSlots.date, date),
+        ),
+      ),
+  ]);
+
+  return baseSlots.filter((slot) => {
+    if (timeToMinutes(slot) <= cutoffMinutes) return false;
+    const slotEnd = minutesToTime(timeToMinutes(slot) + durationMinutes);
+    for (const appt of existingAppts) {
+      if (overlaps(slot, slotEnd, appt.startTime, appt.endTime)) return false;
+    }
+    for (const block of blocked) {
+      if (overlaps(slot, slotEnd, block.startTime, block.endTime)) return false;
+    }
+    return true;
+  });
+}
+
+export async function createAppointment(
+  _prevState: ActionState | null,
+  formData: FormData,
+): Promise<ActionState> {
+  const rawBarberId = formData.get("barberId") as string;
+
+  const raw = {
+    tenantId: formData.get("tenantId") as string,
+    serviceId: formData.get("serviceId") as string,
+    barberId:
+      rawBarberId === "no-preference" ? null : rawBarberId || null,
+    date: formData.get("date") as string,
+    startTime: formData.get("startTime") as string,
+    name: ((formData.get("name") as string) ?? "").trim(),
+    phone: ((formData.get("phone") as string) ?? "").trim(),
+    drink: (formData.get("drink") as string) || undefined,
+    music: (formData.get("music") as string) || undefined,
+  };
+
+  const result = bookingSchema.safeParse(raw);
+  if (!result.success) {
+    return { error: result.error.flatten().fieldErrors };
+  }
+
+  const {
+    tenantId,
+    serviceId,
+    barberId,
+    date,
+    startTime,
+    name,
+    phone,
+    drink,
+    music,
+  } = result.data;
+
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.id, tenantId),
+    columns: { id: true, name: true, slug: true, phone: true },
+  });
+  if (!tenant) return { error: { _form: ["La barbería no existe."] } };
+
+  const service = await db.query.services.findFirst({
+    where: and(
+      eq(services.id, serviceId),
+      eq(services.tenantId, tenantId),
+      eq(services.isActive, true),
+    ),
+    columns: { id: true, name: true, durationMinutes: true },
+  });
+  if (!service) return { error: { _form: ["El servicio no existe."] } };
+
+  let resolvedBarberId: string;
+  let barberName: string;
+
+  if (barberId) {
+    const [barber] = await db
+      .select({ id: barbers.id, displayName: barbers.displayName })
+      .from(barbers)
+      .where(
+        and(
+          eq(barbers.id, barberId),
+          eq(barbers.tenantId, tenantId),
+          eq(barbers.isActive, true),
+        ),
+      )
+      .limit(1);
+    if (!barber) return { error: { _form: ["El barbero no existe."] } };
+    resolvedBarberId = barber.id;
+    barberName = barber.displayName;
+  } else {
+    const [firstBarber] = await db
+      .select({ id: barbers.id, displayName: barbers.displayName })
+      .from(barbers)
+      .where(and(eq(barbers.tenantId, tenantId), eq(barbers.isActive, true)))
+      .limit(1);
+    if (!firstBarber)
+      return { error: { _form: ["No hay barberos disponibles."] } };
+    resolvedBarberId = firstBarber.id;
+    barberName = firstBarber.displayName;
+  }
+
+  const endTime = minutesToTime(
+    timeToMinutes(startTime) + service.durationMinutes,
+  );
+
+  const [conflict] = await db
+    .select({ id: appointments.id })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.tenantId, tenantId),
+        eq(appointments.barberId, resolvedBarberId),
+        eq(appointments.date, date),
+        eq(appointments.startTime, startTime),
+        notInArray(appointments.status, ["cancelled", "no_show"]),
+      ),
+    )
+    .limit(1);
+
+  if (conflict) {
+    return {
+      error: { _form: ["El horario ya no está disponible. Elegí otro."] },
+    };
+  }
+
+  const now = new Date();
+
+  await db.transaction(async (tx) => {
+    const existingClient = await tx.query.clients.findFirst({
+      where: and(eq(clients.tenantId, tenantId), eq(clients.phone, phone)),
+    });
+
+    let clientId: string;
+
+    if (existingClient) {
+      const updatedPreferences: Record<string, string> = {
+        ...existingClient.preferences,
+        ...(drink ? { drink } : {}),
+        ...(music ? { music } : {}),
+      };
+      await tx
+        .update(clients)
+        .set({
+          name,
+          preferences: updatedPreferences,
+          lastVisitAt: now,
+          visitCount: existingClient.visitCount + 1,
+        })
+        .where(eq(clients.id, existingClient.id));
+      clientId = existingClient.id;
+    } else {
+      const preferences: Record<string, string> = {};
+      if (drink) preferences.drink = drink;
+      if (music) preferences.music = music;
+
+      const [newClient] = await tx
+        .insert(clients)
+        .values({
+          tenantId,
+          name,
+          phone,
+          preferences:
+            Object.keys(preferences).length > 0 ? preferences : null,
+          firstVisitAt: now,
+          lastVisitAt: now,
+          visitCount: 1,
+        })
+        .returning({ id: clients.id });
+      clientId = newClient.id;
+    }
+
+    await tx.insert(appointments).values({
+      tenantId,
+      clientId,
+      barberId: resolvedBarberId,
+      serviceId,
+      date,
+      startTime,
+      endTime,
+      status: "pending",
+      source: "landing",
+    });
+  });
+
+  const params = new URLSearchParams({
+    shop: tenant.name,
+    shopPhone: tenant.phone ?? "",
+    service: service.name,
+    barber: barberName,
+    date,
+    time: startTime,
+    duration: String(service.durationMinutes),
+    client: name,
+  });
+
+  redirect(`/${tenant.slug}/reservar/confirmacion?${params.toString()}`);
+}

--- a/app/[slug]/reservar/confirmacion/page.tsx
+++ b/app/[slug]/reservar/confirmacion/page.tsx
@@ -1,0 +1,188 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Check, MessageCircle, Calendar } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Turno confirmado",
+};
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<Record<string, string>>;
+}
+
+function formatDisplayDate(dateStr: string): string {
+  const parts = dateStr.split("-").map(Number);
+  const year = parts[0] ?? 0;
+  const month = parts[1] ?? 1;
+  const day = parts[2] ?? 1;
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString("es-AR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function buildCalendarUrl(
+  shop: string,
+  service: string,
+  barber: string,
+  date: string,
+  time: string,
+  durationMinutes: number,
+): string {
+  const parts = date.split("-").map(Number);
+  const year = parts[0] ?? 0;
+  const month = parts[1] ?? 1;
+  const day = parts[2] ?? 1;
+  const timeParts = time.split(":").map(Number);
+  const hours = timeParts[0] ?? 0;
+  const minutes = timeParts[1] ?? 0;
+
+  function pad(n: number) {
+    return String(n).padStart(2, "0");
+  }
+
+  const startDt = `${year}${pad(month)}${pad(day)}T${pad(hours)}${pad(minutes)}00`;
+  const endDate = new Date(year, month - 1, day, hours, minutes + durationMinutes);
+  const endDt = `${endDate.getFullYear()}${pad(endDate.getMonth() + 1)}${pad(endDate.getDate())}T${pad(endDate.getHours())}${pad(endDate.getMinutes())}00`;
+
+  const params = new URLSearchParams({
+    action: "TEMPLATE",
+    text: `Turno en ${shop}`,
+    dates: `${startDt}/${endDt}`,
+    details: `Servicio: ${service} | Barbero: ${barber}`,
+  });
+
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+}
+
+export default async function ConfirmacionPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { slug } = await params;
+  const sp = await searchParams;
+
+  if (!sp.date || !sp.service) {
+    redirect(`/${slug}/reservar`);
+  }
+
+  const shop = sp.shop ?? "";
+  const shopPhone = sp.shopPhone ?? "";
+  const service = sp.service ?? "";
+  const barber = sp.barber ?? "";
+  const date = sp.date ?? "";
+  const time = sp.time ?? "";
+  const durationMinutes = Number(sp.duration ?? "60");
+  const client = sp.client ?? "";
+
+  const whatsappText = encodeURIComponent(
+    `Hola ${shop}, reservé un turno para el ${date ? formatDisplayDate(date) : date} a las ${time} con ${barber} para ${service}. Mi nombre es ${client}.`,
+  );
+  const cleanPhone = shopPhone.replace(/\D/g, "");
+  const whatsappUrl =
+    cleanPhone.length > 0
+      ? `https://wa.me/${cleanPhone}?text=${whatsappText}`
+      : `https://wa.me/?text=${whatsappText}`;
+
+  const calendarUrl =
+    date && time
+      ? buildCalendarUrl(shop, service, barber, date, time, durationMinutes)
+      : null;
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 px-4 py-16">
+      <div className="max-w-md mx-auto">
+        {/* Success icon */}
+        <div className="flex justify-center mb-8">
+          <div className="w-20 h-20 rounded-full bg-amber-500/20 border-4 border-amber-500 flex items-center justify-center">
+            <Check className="w-10 h-10 text-amber-500" />
+          </div>
+        </div>
+
+        <h1 className="text-3xl font-extrabold text-center text-zinc-100 mb-2">
+          ¡Turno Confirmado!
+        </h1>
+        {client && (
+          <p className="text-center text-zinc-400 mb-8">
+            Te esperamos, {client}
+          </p>
+        )}
+
+        {/* Summary card */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-5 mb-6 space-y-3 text-sm">
+          {shop && (
+            <div className="flex justify-between gap-4">
+              <span className="text-zinc-500 flex-shrink-0">Barbería</span>
+              <span className="text-zinc-200 font-medium text-right">{shop}</span>
+            </div>
+          )}
+          {service && (
+            <div className="flex justify-between gap-4">
+              <span className="text-zinc-500 flex-shrink-0">Servicio</span>
+              <span className="text-zinc-200 font-medium text-right">
+                {service}
+              </span>
+            </div>
+          )}
+          {barber && (
+            <div className="flex justify-between gap-4">
+              <span className="text-zinc-500 flex-shrink-0">Barbero</span>
+              <span className="text-zinc-200 font-medium text-right">
+                {barber}
+              </span>
+            </div>
+          )}
+          {date && (
+            <div className="flex justify-between gap-4">
+              <span className="text-zinc-500 flex-shrink-0">Fecha</span>
+              <span className="text-zinc-200 font-medium text-right capitalize">
+                {formatDisplayDate(date)}
+              </span>
+            </div>
+          )}
+          {time && (
+            <div className="flex justify-between gap-4">
+              <span className="text-zinc-500 flex-shrink-0">Hora</span>
+              <span className="text-amber-400 font-bold text-base">{time}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex flex-col gap-3">
+          <a
+            href={whatsappUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-3 bg-green-600 hover:bg-green-500 text-white font-bold py-3.5 px-6 rounded-xl transition-colors"
+          >
+            <MessageCircle className="w-5 h-5" />
+            Avisar por WhatsApp
+          </a>
+          {calendarUrl && (
+            <a
+              href={calendarUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center gap-3 bg-zinc-800 hover:bg-zinc-700 text-zinc-100 font-bold py-3.5 px-6 rounded-xl border border-zinc-700 transition-colors"
+            >
+              <Calendar className="w-5 h-5" />
+              Agregar al calendario
+            </a>
+          )}
+          <Link
+            href={`/${slug}`}
+            className="text-center text-zinc-500 hover:text-zinc-300 py-3 transition-colors text-sm"
+          >
+            Volver a la barbería
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[slug]/reservar/page.tsx
+++ b/app/[slug]/reservar/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import type { Metadata } from "next";
+
+import { db } from "@/lib/db";
+import { tenants, barbers, services, profiles } from "@/lib/db/schema";
+import BookingWizard from "@/components/booking/booking-wizard";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+const openingHoursSchema = z.record(
+  z.string(),
+  z.object({
+    closed: z.boolean(),
+    open: z.string().optional(),
+    close: z.string().optional(),
+  }),
+);
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.slug, slug),
+    columns: { name: true },
+  });
+  if (!tenant) return {};
+  return { title: `Reservar turno | ${tenant.name}` };
+}
+
+export default async function ReservarPage({ params }: PageProps) {
+  const { slug } = await params;
+
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.slug, slug),
+  });
+  if (!tenant) notFound();
+
+  const [barberList, serviceList] = await Promise.all([
+    db
+      .select({
+        id: barbers.id,
+        displayName: barbers.displayName,
+        bio: barbers.bio,
+        avatarUrl: profiles.avatarUrl,
+      })
+      .from(barbers)
+      .leftJoin(profiles, eq(barbers.profileId, profiles.id))
+      .where(and(eq(barbers.tenantId, tenant.id), eq(barbers.isActive, true))),
+    db
+      .select()
+      .from(services)
+      .where(
+        and(eq(services.tenantId, tenant.id), eq(services.isActive, true)),
+      ),
+  ]);
+
+  const parsedHours = openingHoursSchema.safeParse(tenant.openingHours);
+  const openingHours = parsedHours.success ? parsedHours.data : null;
+
+  return (
+    <BookingWizard
+      tenantId={tenant.id}
+      slug={slug}
+      shopName={tenant.name}
+      services={serviceList.map((s) => ({
+        id: s.id,
+        name: s.name,
+        durationMinutes: s.durationMinutes,
+        price: s.price,
+      }))}
+      barbers={barberList.map((b) => ({
+        id: b.id,
+        displayName: b.displayName,
+        bio: b.bio,
+        avatarUrl: b.avatarUrl ?? null,
+      }))}
+      openingHours={openingHours}
+    />
+  );
+}

--- a/components/booking/booking-wizard.tsx
+++ b/components/booking/booking-wizard.tsx
@@ -1,0 +1,720 @@
+"use client";
+
+import { useState, useTransition, useActionState } from "react";
+import Image from "next/image";
+import {
+  Check,
+  ChevronRight,
+  ChevronLeft,
+  Clock,
+  User,
+  Loader2,
+  Coffee,
+  Music,
+} from "lucide-react";
+import {
+  createAppointment,
+  getAvailableSlots,
+  lookupClient,
+} from "@/actions/booking";
+import type { ActionState } from "@/actions/auth";
+
+interface ServiceItem {
+  id: string;
+  name: string;
+  durationMinutes: number;
+  price: string;
+}
+
+interface BarberItem {
+  id: string;
+  displayName: string;
+  bio: string | null;
+  avatarUrl: string | null;
+}
+
+interface OpeningHoursDay {
+  closed: boolean;
+  open?: string;
+  close?: string;
+}
+
+interface BookingWizardProps {
+  tenantId: string;
+  slug: string;
+  shopName: string;
+  services: ServiceItem[];
+  barbers: BarberItem[];
+  openingHours: Record<string, OpeningHoursDay> | null;
+}
+
+const WEEK_DAYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+];
+const DAY_SHORT = ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"];
+const MONTH_SHORT = [
+  "ene",
+  "feb",
+  "mar",
+  "abr",
+  "may",
+  "jun",
+  "jul",
+  "ago",
+  "sep",
+  "oct",
+  "nov",
+  "dic",
+];
+const NO_PREFERENCE_ID = "no-preference";
+
+function formatPrice(price: string): string {
+  return new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    maximumFractionDigits: 0,
+  }).format(Number(price));
+}
+
+function formatDuration(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h} h ${m} min` : `${h} h`;
+}
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  return ((words[0]?.[0] ?? "") + (words[1]?.[0] ?? "")).toUpperCase();
+}
+
+function get14Days(openingHours: Record<string, OpeningHoursDay> | null) {
+  const days = [];
+  const base = new Date();
+  for (let i = 0; i < 14; i++) {
+    const d = new Date(base);
+    d.setDate(base.getDate() + i);
+    const dayKey = WEEK_DAYS[d.getDay()];
+    const dayData = dayKey ? openingHours?.[dayKey] : undefined;
+    const isOpen = !openingHours || (!!dayData && !dayData.closed);
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    days.push({
+      dateStr: `${yyyy}-${mm}-${dd}`,
+      dayLabel: DAY_SHORT[d.getDay()] ?? "",
+      dayNum: d.getDate(),
+      monthLabel: MONTH_SHORT[d.getMonth()] ?? "",
+      isOpen,
+    });
+  }
+  return days;
+}
+
+function formatDisplayDate(dateStr: string): string {
+  const parts = dateStr.split("-").map(Number);
+  const year = parts[0] ?? 0;
+  const month = parts[1] ?? 1;
+  const day = parts[2] ?? 1;
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString("es-AR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+const STEP_LABELS = ["Servicio", "Barbero", "Horario", "Datos"];
+
+export default function BookingWizard({
+  tenantId,
+  slug,
+  shopName,
+  services,
+  barbers,
+  openingHours,
+}: BookingWizardProps) {
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [selectedService, setSelectedService] = useState<ServiceItem | null>(
+    null,
+  );
+  const [selectedBarberId, setSelectedBarberId] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selectedTime, setSelectedTime] = useState<string | null>(null);
+  const [slots, setSlots] = useState<string[]>([]);
+  const [slotsLoading, startSlotTransition] = useTransition();
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [drink, setDrink] = useState("");
+  const [music, setMusic] = useState("");
+  const [existingClient, setExistingClient] = useState<{
+    id: string;
+    name: string;
+    preferences: Record<string, string> | null;
+  } | null>(null);
+  const [clientLoading, startClientTransition] = useTransition();
+  const [state, formAction, isPending] = useActionState<
+    ActionState | null,
+    FormData
+  >(createAppointment, null);
+
+  const dates = get14Days(openingHours);
+
+  function fetchSlots(date: string, barberId: string | null, duration: number) {
+    setSelectedTime(null);
+    setSlots([]);
+    startSlotTransition(async () => {
+      const effectiveBarberId =
+        barberId === NO_PREFERENCE_ID ? null : barberId;
+      const available = await getAvailableSlots(
+        tenantId,
+        effectiveBarberId,
+        date,
+        duration,
+      );
+      setSlots(available);
+    });
+  }
+
+  function handleDateSelect(dateStr: string) {
+    setSelectedDate(dateStr);
+    if (selectedService) {
+      fetchSlots(dateStr, selectedBarberId, selectedService.durationMinutes);
+    }
+  }
+
+  function handlePhoneBlur() {
+    if (phone.length >= 6) {
+      startClientTransition(async () => {
+        const found = await lookupClient(tenantId, phone);
+        if (found) {
+          setExistingClient(found);
+          if (!name) setName(found.name);
+          if (!drink && found.preferences?.drink)
+            setDrink(found.preferences.drink);
+          if (!music && found.preferences?.music)
+            setMusic(found.preferences.music);
+        }
+      });
+    }
+  }
+
+  const selectedBarberName =
+    selectedBarberId === NO_PREFERENCE_ID
+      ? "Sin preferencia"
+      : (barbers.find((b) => b.id === selectedBarberId)?.displayName ?? "");
+
+  // Step 1 — service selection
+  function renderStep1() {
+    return (
+      <div>
+        <h2 className="text-xl font-bold text-zinc-100 mb-1">
+          Elegí tu servicio
+        </h2>
+        <p className="text-zinc-500 text-sm mb-6">
+          Seleccioná el servicio que querés
+        </p>
+        {services.length === 0 ? (
+          <p className="text-zinc-400 text-center py-10">
+            No hay servicios disponibles
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {services.map((service) => (
+              <button
+                key={service.id}
+                onClick={() => {
+                  setSelectedService(service);
+                  setSelectedDate(null);
+                  setSelectedTime(null);
+                  setSlots([]);
+                }}
+                className={`text-left p-4 rounded-xl border transition-all ${
+                  selectedService?.id === service.id
+                    ? "border-amber-500 bg-amber-500/10"
+                    : "border-zinc-700 bg-zinc-900 hover:border-zinc-600"
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="font-semibold text-zinc-100">
+                    {service.name}
+                  </span>
+                  {selectedService?.id === service.id && (
+                    <Check className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+                  )}
+                </div>
+                <div className="flex items-center justify-between mt-2">
+                  <span className="text-zinc-500 text-sm flex items-center gap-1">
+                    <Clock className="w-3.5 h-3.5" />
+                    {formatDuration(service.durationMinutes)}
+                  </span>
+                  <span className="text-amber-400 font-bold">
+                    {formatPrice(service.price)}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="mt-6 flex justify-end">
+          <button
+            disabled={!selectedService}
+            onClick={() => setStep(2)}
+            className="flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-zinc-800 disabled:text-zinc-600 text-zinc-950 font-bold py-3 px-6 rounded-xl transition-colors"
+          >
+            Continuar
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Step 2 — barber selection
+  function renderStep2() {
+    return (
+      <div>
+        <h2 className="text-xl font-bold text-zinc-100 mb-1">
+          Elegí tu barbero
+        </h2>
+        <p className="text-zinc-500 text-sm mb-6">
+          O continuá sin preferencia
+        </p>
+        <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+          <button
+            onClick={() => setSelectedBarberId(NO_PREFERENCE_ID)}
+            className={`flex flex-col items-center text-center p-3 rounded-xl border transition-all ${
+              selectedBarberId === NO_PREFERENCE_ID
+                ? "border-amber-500 bg-amber-500/10"
+                : "border-zinc-700 bg-zinc-900 hover:border-zinc-600"
+            }`}
+          >
+            <div className="w-14 h-14 rounded-full bg-zinc-800 border-2 border-zinc-700 flex items-center justify-center mb-2">
+              <User className="w-6 h-6 text-zinc-400" />
+            </div>
+            <span className="text-xs font-medium text-zinc-400 leading-tight">
+              Sin preferencia
+            </span>
+            {selectedBarberId === NO_PREFERENCE_ID && (
+              <Check className="w-4 h-4 text-amber-500 mt-1" />
+            )}
+          </button>
+
+          {barbers.map((barber) => (
+            <button
+              key={barber.id}
+              onClick={() => setSelectedBarberId(barber.id)}
+              className={`flex flex-col items-center text-center p-3 rounded-xl border transition-all ${
+                selectedBarberId === barber.id
+                  ? "border-amber-500 bg-amber-500/10"
+                  : "border-zinc-700 bg-zinc-900 hover:border-zinc-600"
+              }`}
+            >
+              {barber.avatarUrl ? (
+                <div className="relative w-14 h-14 rounded-full overflow-hidden mb-2 ring-2 ring-zinc-700">
+                  <Image
+                    src={barber.avatarUrl}
+                    alt={barber.displayName}
+                    fill
+                    sizes="56px"
+                    className="object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="w-14 h-14 rounded-full bg-zinc-800 border-2 border-zinc-700 flex items-center justify-center mb-2 font-bold text-amber-400">
+                  {getInitials(barber.displayName)}
+                </div>
+              )}
+              <span className="text-xs font-medium text-zinc-300 leading-tight line-clamp-2">
+                {barber.displayName}
+              </span>
+              {selectedBarberId === barber.id && (
+                <Check className="w-4 h-4 text-amber-500 mt-1" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-6 flex justify-between">
+          <button
+            onClick={() => setStep(1)}
+            className="flex items-center gap-2 text-zinc-400 hover:text-zinc-200 py-3 px-4 rounded-xl transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Atrás
+          </button>
+          <button
+            disabled={!selectedBarberId}
+            onClick={() => {
+              setSelectedDate(null);
+              setSelectedTime(null);
+              setSlots([]);
+              setStep(3);
+            }}
+            className="flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-zinc-800 disabled:text-zinc-600 text-zinc-950 font-bold py-3 px-6 rounded-xl transition-colors"
+          >
+            Continuar
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Step 3 — date + time selection
+  function renderStep3() {
+    if (!selectedService) return null;
+    return (
+      <div>
+        <h2 className="text-xl font-bold text-zinc-100 mb-1">
+          Fecha y horario
+        </h2>
+        <p className="text-zinc-500 text-sm mb-6">
+          Elegí cuándo querés tu turno
+        </p>
+
+        {/* Date strip */}
+        <div className="flex gap-2 overflow-x-auto pb-2 -mx-4 px-4">
+          {dates.map(({ dateStr, dayLabel, dayNum, monthLabel, isOpen }) => (
+            <button
+              key={dateStr}
+              disabled={!isOpen}
+              onClick={() => handleDateSelect(dateStr)}
+              className={`flex-shrink-0 flex flex-col items-center py-3 px-2 rounded-xl border w-[4.25rem] transition-all ${
+                !isOpen
+                  ? "border-zinc-800 bg-zinc-900/50 opacity-40 cursor-not-allowed"
+                  : selectedDate === dateStr
+                    ? "border-amber-500 bg-amber-500/10"
+                    : "border-zinc-700 bg-zinc-900 hover:border-zinc-600"
+              }`}
+            >
+              <span className="text-xs text-zinc-500 uppercase">{dayLabel}</span>
+              <span
+                className={`text-lg font-bold mt-0.5 ${
+                  selectedDate === dateStr ? "text-amber-400" : "text-zinc-100"
+                }`}
+              >
+                {dayNum}
+              </span>
+              <span className="text-xs text-zinc-500">{monthLabel}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Time slots */}
+        {selectedDate && (
+          <div className="mt-6">
+            <p className="text-sm font-medium text-zinc-400 mb-3">
+              Horarios disponibles —{" "}
+              <span className="capitalize">
+                {formatDisplayDate(selectedDate)}
+              </span>
+            </p>
+            {slotsLoading ? (
+              <div className="flex items-center gap-2 text-zinc-500 py-6">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Cargando horarios...</span>
+              </div>
+            ) : slots.length === 0 ? (
+              <p className="text-zinc-500 text-sm py-6">
+                No hay horarios disponibles para este día
+              </p>
+            ) : (
+              <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
+                {slots.map((slot) => (
+                  <button
+                    key={slot}
+                    onClick={() => setSelectedTime(slot)}
+                    className={`py-2.5 px-3 rounded-lg text-sm font-medium border transition-all ${
+                      selectedTime === slot
+                        ? "border-amber-500 bg-amber-500/10 text-amber-400"
+                        : "border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-600"
+                    }`}
+                  >
+                    {slot}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-between">
+          <button
+            onClick={() => setStep(2)}
+            className="flex items-center gap-2 text-zinc-400 hover:text-zinc-200 py-3 px-4 rounded-xl transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Atrás
+          </button>
+          <button
+            disabled={!selectedDate || !selectedTime}
+            onClick={() => setStep(4)}
+            className="flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-zinc-800 disabled:text-zinc-600 text-zinc-950 font-bold py-3 px-6 rounded-xl transition-colors"
+          >
+            Continuar
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Step 4 — contact info + submit
+  function renderStep4() {
+    const existingDrink = existingClient?.preferences?.drink;
+    const existingMusic = existingClient?.preferences?.music;
+
+    return (
+      <div>
+        <h2 className="text-xl font-bold text-zinc-100 mb-1">Tus datos</h2>
+        <p className="text-zinc-500 text-sm mb-6">Para confirmar tu turno</p>
+
+        {/* Booking summary */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 mb-6 space-y-2.5 text-sm">
+          <div className="flex justify-between gap-4">
+            <span className="text-zinc-500 flex-shrink-0">Servicio</span>
+            <span className="text-zinc-200 font-medium text-right">
+              {selectedService?.name}
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span className="text-zinc-500 flex-shrink-0">Barbero</span>
+            <span className="text-zinc-200 font-medium text-right">
+              {selectedBarberName}
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span className="text-zinc-500 flex-shrink-0">Fecha</span>
+            <span className="text-zinc-200 font-medium text-right capitalize">
+              {selectedDate ? formatDisplayDate(selectedDate) : ""}
+            </span>
+          </div>
+          <div className="flex justify-between gap-4">
+            <span className="text-zinc-500 flex-shrink-0">Hora</span>
+            <span className="text-amber-400 font-bold">{selectedTime}</span>
+          </div>
+        </div>
+
+        {existingClient && (
+          <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl p-4 mb-6">
+            <p className="text-amber-300 text-sm font-medium">
+              ¡Hola {existingClient.name}!{" "}
+              {existingDrink
+                ? `¿Querés el mismo corte de siempre con tu ${existingDrink}?`
+                : "¡Bienvenido de vuelta!"}
+            </p>
+          </div>
+        )}
+
+        <form action={formAction} className="space-y-4">
+          <input type="hidden" name="tenantId" value={tenantId} />
+          <input
+            type="hidden"
+            name="serviceId"
+            value={selectedService?.id ?? ""}
+          />
+          <input
+            type="hidden"
+            name="barberId"
+            value={selectedBarberId ?? NO_PREFERENCE_ID}
+          />
+          <input type="hidden" name="date" value={selectedDate ?? ""} />
+          <input type="hidden" name="startTime" value={selectedTime ?? ""} />
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Nombre <span className="text-amber-500">*</span>
+            </label>
+            <input
+              type="text"
+              name="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              placeholder="Tu nombre"
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500"
+            />
+            {state?.error?.name && (
+              <p className="mt-1 text-xs text-red-400">{state.error.name[0]}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+              Teléfono <span className="text-amber-500">*</span>
+            </label>
+            <input
+              type="tel"
+              name="phone"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              onBlur={handlePhoneBlur}
+              required
+              placeholder="Tu teléfono"
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500"
+            />
+            {clientLoading && (
+              <p className="mt-1 text-xs text-zinc-500 flex items-center gap-1">
+                <Loader2 className="w-3 h-3 animate-spin" />
+                Buscando tu perfil...
+              </p>
+            )}
+            {state?.error?.phone && (
+              <p className="mt-1 text-xs text-red-400">
+                {state.error.phone[0]}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+              <span className="flex items-center gap-1.5">
+                <Coffee className="w-4 h-4 text-zinc-500" />
+                Bebida preferida{" "}
+                <span className="text-zinc-600 font-normal">(opcional)</span>
+              </span>
+            </label>
+            <input
+              type="text"
+              name="drink"
+              value={drink}
+              onChange={(e) => setDrink(e.target.value)}
+              placeholder={existingDrink ?? "Café, mate, agua..."}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-zinc-300 mb-1.5">
+              <span className="flex items-center gap-1.5">
+                <Music className="w-4 h-4 text-zinc-500" />
+                Música preferida{" "}
+                <span className="text-zinc-600 font-normal">(opcional)</span>
+              </span>
+            </label>
+            <input
+              type="text"
+              name="music"
+              value={music}
+              onChange={(e) => setMusic(e.target.value)}
+              placeholder={existingMusic ?? "Rock, reggaeton, jazz..."}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-3 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500"
+            />
+          </div>
+
+          {state?.error?._form && (
+            <div className="rounded-xl bg-red-950/50 border border-red-800 p-4">
+              <p className="text-sm text-red-400">{state.error._form[0]}</p>
+            </div>
+          )}
+
+          <div className="flex justify-between pt-2">
+            <button
+              type="button"
+              onClick={() => setStep(3)}
+              className="flex items-center gap-2 text-zinc-400 hover:text-zinc-200 py-3 px-4 rounded-xl transition-colors"
+            >
+              <ChevronLeft className="w-4 h-4" />
+              Atrás
+            </button>
+            <button
+              type="submit"
+              disabled={isPending || !name.trim() || !phone.trim()}
+              className="flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-zinc-800 disabled:text-zinc-600 text-zinc-950 font-bold py-3 px-6 rounded-xl transition-colors"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Confirmando...
+                </>
+              ) : (
+                "Confirmar turno"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      {/* Header */}
+      <header className="sticky top-0 z-40 bg-zinc-950/90 backdrop-blur-sm border-b border-zinc-800">
+        <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-3">
+          <a
+            href={`/${slug}`}
+            className="text-zinc-400 hover:text-zinc-200 transition-colors flex-shrink-0"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </a>
+          <div className="min-w-0">
+            <p className="text-xs text-zinc-500 truncate">{shopName}</p>
+            <p className="font-bold text-zinc-100">Reservar turno</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6 pb-16">
+        {/* Step indicator */}
+        <div className="flex items-start mb-8">
+          {STEP_LABELS.map((label, index) => {
+            const stepNum = (index + 1) as 1 | 2 | 3 | 4;
+            const isCompleted = step > stepNum;
+            const isCurrent = step === stepNum;
+            return (
+              <div
+                key={stepNum}
+                className={`flex items-start ${index < 3 ? "flex-1" : ""}`}
+              >
+                <div className="flex flex-col items-center">
+                  <div
+                    className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold transition-colors ${
+                      isCompleted
+                        ? "bg-amber-500 text-zinc-950"
+                        : isCurrent
+                          ? "bg-transparent border-2 border-amber-500 text-amber-400"
+                          : "bg-zinc-800 border-2 border-zinc-700 text-zinc-600"
+                    }`}
+                  >
+                    {isCompleted ? <Check className="w-4 h-4" /> : stepNum}
+                  </div>
+                  <span
+                    className={`text-xs mt-1.5 whitespace-nowrap ${
+                      isCurrent
+                        ? "text-amber-400"
+                        : isCompleted
+                          ? "text-zinc-400"
+                          : "text-zinc-600"
+                    }`}
+                  >
+                    {label}
+                  </span>
+                </div>
+                {index < 3 && (
+                  <div
+                    className={`flex-1 h-px mt-4 mx-1 ${
+                      step > stepNum ? "bg-amber-500" : "bg-zinc-800"
+                    }`}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {step === 1 && renderStep1()}
+        {step === 2 && renderStep2()}
+        {step === 3 && renderStep3()}
+        {step === 4 && renderStep4()}
+      </main>
+    </div>
+  );
+}

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const bookingSchema = z.object({
+  tenantId: z.string().uuid(),
+  serviceId: z.string().uuid(),
+  barberId: z.string().uuid().nullable(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Fecha inválida"),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/, "Hora inválida"),
+  name: z.string().min(1, "El nombre es requerido"),
+  phone: z.string().min(6, "El teléfono es requerido"),
+  drink: z.string().optional(),
+  music: z.string().optional(),
+});
+
+export type BookingInput = z.infer<typeof bookingSchema>;


### PR DESCRIPTION
## feat: wizard de reserva de turno /[slug]/reservar

### Qué incluye
- Wizard de 4 pasos: servicio, barbero, fecha/horario, confirmación
- Reconocimiento de cliente recurrente por teléfono con mensaje 
  personalizado y preferencias pre-completadas
- Cálculo de slots disponibles excluyendo appointments y blocked_slots
- Upsert de client con preferencias (bebida, música) y visitCount
- Página de confirmación con resumen, botón WhatsApp y Google Calendar
- Fix de double-booking con "Sin preferencia" de barbero
- Transacción en createAppointment — rollback si el insert falla
- Guard en confirmación — redirect si faltan params

### Issues trackeados
#17  #18  #19  #20 
