### PR TITLE
feat: appointments dashboard with day timeline and week grid

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,10 @@
       "Bash(npm:*)",
       "Bash(pnpm create:*)",
       "mcp__stitch__list_screens",
-      "mcp__stitch__get_screen"
+      "mcp__stitch__get_screen",
+      "Bash(ls:*)",
+      "Bash(grep -r base-ui C:/Users/Agustin/Documents/Proyectos/Barber/components --include=*.tsx -l)",
+      "Bash(grep -r @base-ui C:/Users/Agustin/Documents/Proyectos/Barber --include=*.tsx -l)"
     ]
   }
 }

--- a/actions/appointments.ts
+++ b/actions/appointments.ts
@@ -1,0 +1,508 @@
+"use server";
+
+import { and, eq, gte, ilike, lte, notInArray, or } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import {
+  appointments,
+  barbers,
+  clients,
+  profiles,
+  services,
+} from "@/lib/db/schema";
+import { createClient } from "@/lib/supabase/server";
+import type { AppointmentStatus } from "@/lib/db/schema/appointments";
+import type { ActionState } from "@/actions/auth";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export type AppointmentRow = {
+  id: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  status: AppointmentStatus;
+  notes: string | null;
+  barberId: string;
+  barberDisplayName: string;
+  clientId: string;
+  clientName: string;
+  clientPhone: string | null;
+  clientEmail: string | null;
+  clientPreferences: Record<string, string> | null;
+  serviceId: string;
+  serviceName: string;
+  serviceDurationMinutes: number;
+  servicePrice: string;
+};
+
+export type BarberOption = { id: string; displayName: string };
+
+export type ServiceOption = {
+  id: string;
+  name: string;
+  durationMinutes: number;
+  price: string;
+};
+
+export type ClientSearchResult = {
+  id: string;
+  name: string;
+  phone: string | null;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTime(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+type AuthContext = {
+  userId: string;
+  tenantId: string;
+  role: "owner" | "barber";
+  ownBarberId: string | null;
+};
+
+async function getAuthContext(): Promise<AuthContext | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const profile = await db.query.profiles.findFirst({
+    where: eq(profiles.id, user.id),
+    columns: { tenantId: true, role: true },
+  });
+  if (!profile?.tenantId) return null;
+
+  const tenantId = profile.tenantId;
+  const role = profile.role === "barber" ? "barber" : "owner";
+
+  let ownBarberId: string | null = null;
+  if (role === "barber") {
+    const [barber] = await db
+      .select({ id: barbers.id })
+      .from(barbers)
+      .where(
+        and(eq(barbers.profileId, user.id), eq(barbers.tenantId, tenantId)),
+      )
+      .limit(1);
+    ownBarberId = barber?.id ?? null;
+  }
+
+  return { userId: user.id, tenantId, role, ownBarberId };
+}
+
+async function fetchRows(
+  tenantId: string,
+  dateFilter: ReturnType<typeof eq> | ReturnType<typeof and>,
+  barberId?: string,
+): Promise<AppointmentRow[]> {
+  const rows = await db
+    .select({
+      id: appointments.id,
+      date: appointments.date,
+      startTime: appointments.startTime,
+      endTime: appointments.endTime,
+      status: appointments.status,
+      notes: appointments.notes,
+      barberId: barbers.id,
+      barberDisplayName: barbers.displayName,
+      clientId: clients.id,
+      clientName: clients.name,
+      clientPhone: clients.phone,
+      clientEmail: clients.email,
+      clientPreferences: clients.preferences,
+      serviceId: services.id,
+      serviceName: services.name,
+      serviceDurationMinutes: services.durationMinutes,
+      servicePrice: services.price,
+    })
+    .from(appointments)
+    .innerJoin(barbers, eq(appointments.barberId, barbers.id))
+    .innerJoin(clients, eq(appointments.clientId, clients.id))
+    .innerJoin(services, eq(appointments.serviceId, services.id))
+    .where(
+      and(
+        eq(appointments.tenantId, tenantId),
+        dateFilter,
+        ...(barberId ? [eq(appointments.barberId, barberId)] : []),
+      ),
+    )
+    .orderBy(appointments.startTime);
+
+  return rows.map((r) => ({
+    ...r,
+    servicePrice: String(r.servicePrice),
+    clientPreferences: r.clientPreferences as Record<string, string> | null,
+  }));
+}
+
+// ─── Fetch server actions ─────────────────────────────────────────────────────
+
+export async function getAppointmentsForDay(
+  date: string,
+  filterBarberId?: string,
+): Promise<AppointmentRow[]> {
+  const ctx = await getAuthContext();
+  if (!ctx) return [];
+
+  const { tenantId, role, ownBarberId } = ctx;
+  const effectiveBarberId =
+    role === "barber" ? (ownBarberId ?? undefined) : filterBarberId;
+
+  return fetchRows(tenantId, eq(appointments.date, date), effectiveBarberId);
+}
+
+export async function getAppointmentsForWeek(
+  weekStart: string,
+  weekEnd: string,
+  filterBarberId?: string,
+): Promise<AppointmentRow[]> {
+  const ctx = await getAuthContext();
+  if (!ctx) return [];
+
+  const { tenantId, role, ownBarberId } = ctx;
+  const effectiveBarberId =
+    role === "barber" ? (ownBarberId ?? undefined) : filterBarberId;
+
+  return fetchRows(
+    tenantId,
+    and(gte(appointments.date, weekStart), lte(appointments.date, weekEnd))!,
+    effectiveBarberId,
+  );
+}
+
+export async function searchClients(
+  query: string,
+): Promise<ClientSearchResult[]> {
+  const ctx = await getAuthContext();
+  if (!ctx) return [];
+
+  const { tenantId } = ctx;
+  const term = `%${query.trim()}%`;
+
+  const rows = await db
+    .select({ id: clients.id, name: clients.name, phone: clients.phone })
+    .from(clients)
+    .where(
+      and(
+        eq(clients.tenantId, tenantId),
+        or(ilike(clients.name, term), ilike(clients.phone, term)),
+      ),
+    )
+    .limit(10);
+
+  return rows;
+}
+
+// ─── Mutation server actions ──────────────────────────────────────────────────
+
+export async function updateAppointmentStatus(
+  appointmentId: string,
+  status: AppointmentStatus,
+): Promise<ActionState> {
+  const ctx = await getAuthContext();
+  if (!ctx) return { error: { _form: ["No autorizado"] } };
+
+  const { tenantId, role, ownBarberId } = ctx;
+
+  const [appt] = await db
+    .select({
+      id: appointments.id,
+      barberId: appointments.barberId,
+      status: appointments.status,
+    })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.id, appointmentId),
+        eq(appointments.tenantId, tenantId),
+      ),
+    )
+    .limit(1);
+
+  if (!appt) return { error: { _form: ["Turno no encontrado"] } };
+
+  if (role === "barber" && !ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+  if (role === "barber" && ownBarberId && appt.barberId !== ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+
+  const allowed: Record<AppointmentStatus, AppointmentStatus[]> = {
+    pending: ["confirmed", "cancelled"],
+    confirmed: ["completed", "cancelled"],
+    completed: [],
+    cancelled: [],
+    no_show: [],
+  };
+
+  if (!allowed[appt.status].includes(status)) {
+    return { error: { _form: ["Transición de estado no permitida"] } };
+  }
+
+  await db
+    .update(appointments)
+    .set({ status })
+    .where(eq(appointments.id, appointmentId));
+
+  return { success: true };
+}
+
+export async function updateAppointmentNotes(
+  appointmentId: string,
+  notes: string,
+): Promise<ActionState> {
+  const ctx = await getAuthContext();
+  if (!ctx) return { error: { _form: ["No autorizado"] } };
+
+  const { tenantId, role, ownBarberId } = ctx;
+
+  const [appt] = await db
+    .select({ id: appointments.id, barberId: appointments.barberId })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.id, appointmentId),
+        eq(appointments.tenantId, tenantId),
+      ),
+    )
+    .limit(1);
+
+  if (!appt) return { error: { _form: ["Turno no encontrado"] } };
+
+  if (role === "barber" && !ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+  if (role === "barber" && ownBarberId && appt.barberId !== ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+
+  await db
+    .update(appointments)
+    .set({ notes: notes.trim() || null })
+    .where(eq(appointments.id, appointmentId));
+
+  return { success: true };
+}
+
+export async function rescheduleAppointment(
+  appointmentId: string,
+): Promise<ActionState> {
+  const ctx = await getAuthContext();
+  if (!ctx) return { error: { _form: ["No autorizado"] } };
+
+  const { tenantId, role, ownBarberId } = ctx;
+
+  const [appt] = await db
+    .select({
+      id: appointments.id,
+      barberId: appointments.barberId,
+      status: appointments.status,
+    })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.id, appointmentId),
+        eq(appointments.tenantId, tenantId),
+      ),
+    )
+    .limit(1);
+
+  if (!appt) return { error: { _form: ["Turno no encontrado"] } };
+
+  if (role === "barber" && !ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+  if (role === "barber" && ownBarberId && appt.barberId !== ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+
+  if (appt.status === "completed" || appt.status === "cancelled") {
+    return { error: { _form: ["No se puede reprogramar este turno"] } };
+  }
+
+  await db
+    .update(appointments)
+    .set({
+      status: "cancelled",
+      notes: "Reprogramado — cliente debe reservar de nuevo",
+    })
+    .where(eq(appointments.id, appointmentId));
+
+  return { success: true };
+}
+
+// ─── Create manual appointment ────────────────────────────────────────────────
+
+const manualAppointmentSchema = z.object({
+  clientId: z.string().uuid().optional(),
+  clientName: z.string().min(1, "Nombre requerido").max(100),
+  clientPhone: z.string().optional(),
+  barberId: z.string().uuid("Barbero requerido"),
+  serviceId: z.string().uuid("Servicio requerido"),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Fecha inválida"),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/, "Hora inválida"),
+});
+
+export async function createManualAppointment(
+  _prev: ActionState | null,
+  formData: FormData,
+): Promise<ActionState> {
+  const ctx = await getAuthContext();
+  if (!ctx) return { error: { _form: ["No autorizado"] } };
+
+  const { tenantId, role, ownBarberId } = ctx;
+
+  const raw = {
+    clientId: (formData.get("clientId") as string) || undefined,
+    clientName: ((formData.get("clientName") as string) ?? "").trim(),
+    clientPhone:
+      ((formData.get("clientPhone") as string) ?? "").trim() || undefined,
+    barberId: formData.get("barberId") as string,
+    serviceId: formData.get("serviceId") as string,
+    date: formData.get("date") as string,
+    startTime: formData.get("startTime") as string,
+  };
+
+  const result = manualAppointmentSchema.safeParse(raw);
+  if (!result.success) {
+    return { error: result.error.flatten().fieldErrors };
+  }
+
+  const data = result.data;
+
+  if (role === "barber" && !ownBarberId) {
+    return { error: { _form: ["No autorizado"] } };
+  }
+  if (role === "barber" && ownBarberId && data.barberId !== ownBarberId) {
+    return { error: { _form: ["No podés crear turnos para otro barbero"] } };
+  }
+
+  if (data.clientId) {
+    const [clientCheck] = await db
+      .select({ id: clients.id })
+      .from(clients)
+      .where(
+        and(eq(clients.id, data.clientId), eq(clients.tenantId, tenantId)),
+      )
+      .limit(1);
+    if (!clientCheck) return { error: { _form: ["Cliente no válido"] } };
+  }
+
+  const [barber] = await db
+    .select({ id: barbers.id })
+    .from(barbers)
+    .where(
+      and(
+        eq(barbers.id, data.barberId),
+        eq(barbers.tenantId, tenantId),
+        eq(barbers.isActive, true),
+      ),
+    )
+    .limit(1);
+  if (!barber) return { error: { _form: ["Barbero no válido"] } };
+
+  const [service] = await db
+    .select({ id: services.id, durationMinutes: services.durationMinutes })
+    .from(services)
+    .where(
+      and(
+        eq(services.id, data.serviceId),
+        eq(services.tenantId, tenantId),
+        eq(services.isActive, true),
+      ),
+    )
+    .limit(1);
+  if (!service) return { error: { _form: ["Servicio no válido"] } };
+
+  const endTime = minutesToTime(
+    timeToMinutes(data.startTime) + service.durationMinutes,
+  );
+
+  const [conflict] = await db
+    .select({ id: appointments.id })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.tenantId, tenantId),
+        eq(appointments.barberId, data.barberId),
+        eq(appointments.date, data.date),
+        eq(appointments.startTime, data.startTime),
+        notInArray(appointments.status, ["cancelled", "no_show"]),
+      ),
+    )
+    .limit(1);
+
+  if (conflict) {
+    return { error: { _form: ["El horario ya está ocupado. Elegí otro."] } };
+  }
+
+  const now = new Date();
+
+  await db.transaction(async (tx) => {
+    let clientId = data.clientId;
+
+    if (!clientId) {
+      if (data.clientPhone) {
+        const existing = await tx.query.clients.findFirst({
+          where: and(
+            eq(clients.tenantId, tenantId),
+            eq(clients.phone, data.clientPhone),
+          ),
+        });
+        if (existing) {
+          await tx
+            .update(clients)
+            .set({
+              name: data.clientName,
+              lastVisitAt: now,
+              visitCount: existing.visitCount + 1,
+            })
+            .where(eq(clients.id, existing.id));
+          clientId = existing.id;
+        }
+      }
+
+      if (!clientId) {
+        const [newClient] = await tx
+          .insert(clients)
+          .values({
+            tenantId,
+            name: data.clientName,
+            phone: data.clientPhone ?? null,
+            firstVisitAt: now,
+            lastVisitAt: now,
+            visitCount: 1,
+          })
+          .returning({ id: clients.id });
+        clientId = newClient.id;
+      }
+    }
+
+    await tx.insert(appointments).values({
+      tenantId,
+      clientId: clientId!,
+      barberId: data.barberId,
+      serviceId: data.serviceId,
+      date: data.date,
+      startTime: data.startTime,
+      endTime,
+      status: "pending",
+      source: "manual",
+    });
+  });
+
+  return { success: true };
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -153,7 +153,7 @@ export default async function DashboardPage() {
             <h2 className="text-xl font-bold tracking-tight">Próximos Turnos</h2>
           </div>
           <Link
-            href="#"
+            href="/dashboard/turnos"
             className="text-xs font-semibold uppercase tracking-[0.1em] text-primary hover:underline"
           >
             Ver todos

--- a/app/(dashboard)/dashboard/turnos/page.tsx
+++ b/app/(dashboard)/dashboard/turnos/page.tsx
@@ -1,0 +1,119 @@
+import { redirect } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+import { createClient } from "@/lib/supabase/server";
+import { db } from "@/lib/db";
+import {
+  profiles,
+  tenants,
+  barbers as barbersTable,
+  services as servicesTable,
+} from "@/lib/db/schema";
+import { getAppointmentsForDay } from "@/actions/appointments";
+import { AgendaView } from "@/components/dashboard/turnos/agenda-view";
+import type { BarberOption, ServiceOption } from "@/actions/appointments";
+
+export const metadata = {
+  title: "Turnos — BarberSaaS",
+};
+
+function todayISO(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+export default async function TurnosPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const profile = await db.query.profiles.findFirst({
+    where: eq(profiles.id, user.id),
+    columns: { tenantId: true, role: true },
+  });
+
+  if (!profile?.tenantId) redirect("/onboarding/step-1");
+
+  const tenantId = profile.tenantId;
+  const userRole = profile.role === "barber" ? "barber" : "owner";
+
+  const today = todayISO();
+
+  // Find the barber record for this user (barber role only)
+  let ownBarberId: string | null = null;
+  if (userRole === "barber") {
+    const [barber] = await db
+      .select({ id: barbersTable.id })
+      .from(barbersTable)
+      .where(
+        and(
+          eq(barbersTable.profileId, user.id),
+          eq(barbersTable.tenantId, tenantId),
+        ),
+      )
+      .limit(1);
+    ownBarberId = barber?.id ?? null;
+  }
+
+  const [tenant, tenantBarbers, tenantServices, initialAppointments] =
+    await Promise.all([
+      db.query.tenants.findFirst({
+        where: eq(tenants.id, tenantId),
+        columns: { openingHours: true },
+      }),
+      db
+        .select({ id: barbersTable.id, displayName: barbersTable.displayName })
+        .from(barbersTable)
+        .where(
+          and(
+            eq(barbersTable.tenantId, tenantId),
+            eq(barbersTable.isActive, true),
+          ),
+        )
+        .orderBy(barbersTable.displayName),
+      db
+        .select({
+          id: servicesTable.id,
+          name: servicesTable.name,
+          durationMinutes: servicesTable.durationMinutes,
+          price: servicesTable.price,
+        })
+        .from(servicesTable)
+        .where(
+          and(
+            eq(servicesTable.tenantId, tenantId),
+            eq(servicesTable.isActive, true),
+          ),
+        )
+        .orderBy(servicesTable.name),
+      getAppointmentsForDay(today),
+    ]);
+
+  const barbers: BarberOption[] = tenantBarbers;
+  const services: ServiceOption[] = tenantServices.map((s) => ({
+    ...s,
+    price: String(s.price),
+  }));
+
+  return (
+    <div className="min-h-screen bg-background">
+      <AgendaView
+        initialDate={today}
+        initialAppointments={initialAppointments}
+        userRole={userRole}
+        ownBarberId={ownBarberId}
+        tenantId={tenantId}
+        barbers={barbers}
+        services={services}
+        openingHours={
+          tenant?.openingHours as Record<
+            string,
+            { closed?: boolean; open?: string; close?: string }
+          > | null
+        }
+      />
+    </div>
+  );
+}

--- a/components/dashboard/top-nav.tsx
+++ b/components/dashboard/top-nav.tsx
@@ -1,5 +1,9 @@
-import { Scissors, LogOut, ExternalLink } from "lucide-react";
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Scissors, LogOut, ExternalLink, LayoutDashboard, CalendarClock } from "lucide-react";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 import { logout } from "@/actions/auth";
 
 interface DashboardTopNavProps {
@@ -8,15 +12,22 @@ interface DashboardTopNavProps {
   tenantName?: string;
 }
 
+const NAV_ITEMS = [
+  { href: "/dashboard", label: "Resumen", icon: LayoutDashboard },
+  { href: "/dashboard/turnos", label: "Turnos", icon: CalendarClock },
+];
+
 export function DashboardTopNav({
   userEmail,
   tenantSlug,
   tenantName,
 }: DashboardTopNavProps) {
+  const pathname = usePathname();
+
   return (
     <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
+      {/* Main row */}
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-
         {/* Brand + tenant */}
         <Link
           href="/dashboard"
@@ -71,6 +82,31 @@ export function DashboardTopNav({
             </button>
           </form>
         </div>
+      </div>
+
+      {/* Nav tabs row */}
+      <div className="mx-auto flex max-w-5xl items-end gap-0 px-4">
+        {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
+          const isActive =
+            href === "/dashboard"
+              ? pathname === "/dashboard"
+              : pathname.startsWith(href);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={cn(
+                "flex items-center gap-1.5 border-b-2 px-3 py-2 text-xs font-medium transition-colors",
+                isActive
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:border-border hover:text-foreground",
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              {label}
+            </Link>
+          );
+        })}
       </div>
     </header>
   );

--- a/components/dashboard/turnos/agenda-view.tsx
+++ b/components/dashboard/turnos/agenda-view.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useCallback, useState, useTransition } from "react";
+import {
+  getAppointmentsForDay,
+  getAppointmentsForWeek,
+} from "@/actions/appointments";
+import { DateNavigator } from "./date-navigator";
+import { DayTimeline } from "./day-timeline";
+import { WeekGrid } from "./week-grid";
+import { AppointmentModal } from "./appointment-modal";
+import { NewAppointmentModal } from "./new-appointment-modal";
+import type {
+  AppointmentRow,
+  BarberOption,
+  ServiceOption,
+} from "@/actions/appointments";
+
+type OpeningHours = Record<
+  string,
+  { closed?: boolean; open?: string; close?: string }
+>;
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function shiftDate(dateStr: string, days: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  date.setDate(date.getDate() + days);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function getWeekBounds(dateStr: string): { start: string; end: string } {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  const dow = date.getDay();
+  const diff = dow === 0 ? -6 : 1 - dow;
+  const monday = new Date(date);
+  monday.setDate(date.getDate() + diff);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const fmt = (dt: Date) =>
+    `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
+  return { start: fmt(monday), end: fmt(sunday) };
+}
+
+// ─── Barber filter (owner only) ───────────────────────────────────────────────
+
+interface BarberFilterProps {
+  barbers: BarberOption[];
+  selectedId: string;
+  onChange: (id: string) => void;
+}
+
+function BarberFilter({ barbers, selectedId, onChange }: BarberFilterProps) {
+  if (barbers.length <= 1) return null;
+  return (
+    <div className="mx-auto max-w-5xl px-4 pb-2 pt-3">
+      <div className="flex items-center gap-2 overflow-x-auto pb-1">
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          Barbero
+        </span>
+        <button
+          onClick={() => onChange("")}
+          className={`shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+            selectedId === ""
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border bg-muted/30 text-muted-foreground hover:border-primary/40 hover:text-foreground"
+          }`}
+        >
+          Todos
+        </button>
+        {barbers.map((b) => (
+          <button
+            key={b.id}
+            onClick={() => onChange(b.id)}
+            className={`shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              selectedId === b.id
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-muted/30 text-muted-foreground hover:border-primary/40 hover:text-foreground"
+            }`}
+          >
+            {b.displayName}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface AgendaViewProps {
+  initialDate: string;
+  initialAppointments: AppointmentRow[];
+  userRole: "owner" | "barber";
+  ownBarberId: string | null;
+  tenantId: string;
+  barbers: BarberOption[];
+  services: ServiceOption[];
+  openingHours: OpeningHours | null;
+}
+
+export function AgendaView({
+  initialDate,
+  initialAppointments,
+  userRole,
+  ownBarberId,
+  tenantId,
+  barbers,
+  services,
+  openingHours,
+}: AgendaViewProps) {
+  const [currentDate, setCurrentDate] = useState(initialDate);
+  const [viewMode, setViewMode] = useState<"day" | "week">("day");
+  const [selectedBarberId, setSelectedBarberId] = useState("");
+  const [appointments, setAppointments] = useState<AppointmentRow[]>(initialAppointments);
+  const [isPending, startTransition] = useTransition();
+
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedAppt, setSelectedAppt] = useState<AppointmentRow | null>(null);
+  const [newOpen, setNewOpen] = useState(false);
+
+  // Need tenantId for new appointment — get from barbers (owner has access to all)
+  // We'll pass it from barbers context. For now, derive it from the appointments or
+  // use a workaround: the tenantId is opaque to client, but createManualAppointment
+  // reads it server-side from auth context. So we don't need to pass it.
+
+  const refresh = useCallback(
+    (date: string, barberId: string, mode: "day" | "week") => {
+      startTransition(async () => {
+        let data: AppointmentRow[];
+        if (mode === "day") {
+          data = await getAppointmentsForDay(
+            date,
+            barberId || undefined,
+          );
+        } else {
+          const { start, end } = getWeekBounds(date);
+          data = await getAppointmentsForWeek(
+            start,
+            end,
+            barberId || undefined,
+          );
+        }
+        setAppointments(data);
+      });
+    },
+    [],
+  );
+
+  function navigate(direction: -1 | 1) {
+    const delta = viewMode === "week" ? direction * 7 : direction;
+    const newDate = shiftDate(currentDate, delta);
+    setCurrentDate(newDate);
+    refresh(newDate, selectedBarberId, viewMode);
+  }
+
+  function goToday() {
+    const today = new Date();
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+    setCurrentDate(todayStr);
+    refresh(todayStr, selectedBarberId, viewMode);
+  }
+
+  function changeViewMode(mode: "day" | "week") {
+    setViewMode(mode);
+    refresh(currentDate, selectedBarberId, mode);
+  }
+
+  function changeBarber(barberId: string) {
+    setSelectedBarberId(barberId);
+    refresh(currentDate, barberId, viewMode);
+  }
+
+  function openDetail(appt: AppointmentRow) {
+    setSelectedAppt(appt);
+    setDetailOpen(true);
+  }
+
+  function handleRefresh() {
+    refresh(currentDate, selectedBarberId, viewMode);
+  }
+
+  return (
+    <div className="pb-20">
+      {/* Sticky sub-header */}
+      <DateNavigator
+        currentDate={currentDate}
+        viewMode={viewMode}
+        onNavigate={navigate}
+        onViewModeChange={changeViewMode}
+        onToday={goToday}
+        onNewAppointment={() => setNewOpen(true)}
+        isPending={isPending}
+      />
+
+      {/* Barber filter (owner only) */}
+      {userRole === "owner" && (
+        <BarberFilter
+          barbers={barbers}
+          selectedId={selectedBarberId}
+          onChange={changeBarber}
+        />
+      )}
+
+      {/* Loading overlay */}
+      {isPending && (
+        <div className="mx-auto max-w-5xl px-4 py-2">
+          <div className="h-0.5 w-full overflow-hidden rounded-full bg-border">
+            <div className="h-full w-1/2 animate-pulse rounded-full bg-primary/60" />
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      {viewMode === "day" ? (
+        <DayTimeline
+          date={currentDate}
+          appointments={appointments}
+          openingHours={openingHours}
+          onAppointmentClick={openDetail}
+        />
+      ) : (
+        <WeekGrid
+          currentDate={currentDate}
+          appointments={appointments}
+          onAppointmentClick={openDetail}
+        />
+      )}
+
+      {/* Appointment detail modal */}
+      <AppointmentModal
+        appointment={selectedAppt}
+        open={detailOpen}
+        onClose={() => setDetailOpen(false)}
+        onRefresh={handleRefresh}
+      />
+
+      {/* New appointment modal */}
+      <NewAppointmentModal
+        open={newOpen}
+        onClose={() => setNewOpen(false)}
+        onSuccess={handleRefresh}
+        barbers={barbers}
+        services={services}
+        userRole={userRole}
+        ownBarberId={ownBarberId}
+        tenantId={tenantId}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/turnos/appointment-block.tsx
+++ b/components/dashboard/turnos/appointment-block.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { AppointmentRow } from "@/actions/appointments";
+
+type AppointmentStatus = AppointmentRow["status"];
+
+const STATUS_STYLES: Record<
+  AppointmentStatus,
+  { dot: string; bg: string; border: string; text: string; label: string }
+> = {
+  pending: {
+    dot: "bg-amber-400",
+    bg: "bg-amber-500/8 hover:bg-amber-500/12",
+    border: "border-amber-500/25",
+    text: "text-amber-300",
+    label: "Pendiente",
+  },
+  confirmed: {
+    dot: "bg-emerald-400",
+    bg: "bg-emerald-500/8 hover:bg-emerald-500/12",
+    border: "border-emerald-500/25",
+    text: "text-emerald-300",
+    label: "Confirmado",
+  },
+  completed: {
+    dot: "bg-zinc-500",
+    bg: "bg-muted/30 hover:bg-muted/50",
+    border: "border-border",
+    text: "text-muted-foreground",
+    label: "Completado",
+  },
+  cancelled: {
+    dot: "bg-red-500",
+    bg: "bg-red-500/6 hover:bg-red-500/10",
+    border: "border-red-500/20",
+    text: "text-red-400/70",
+    label: "Cancelado",
+  },
+  no_show: {
+    dot: "bg-red-500",
+    bg: "bg-red-500/10 hover:bg-red-500/15",
+    border: "border-red-500/30",
+    text: "text-red-400",
+    label: "No se presentó",
+  },
+};
+
+interface AppointmentBlockProps {
+  appointment: AppointmentRow;
+  onClick: (appointment: AppointmentRow) => void;
+  /** For timeline: top offset in px */
+  topPx?: number;
+  /** For timeline: height in px */
+  heightPx?: number;
+  /** Whether rendering in timeline (absolute) or list (relative) */
+  mode?: "timeline" | "list";
+}
+
+export function AppointmentBlock({
+  appointment,
+  onClick,
+  topPx,
+  heightPx,
+  mode = "list",
+}: AppointmentBlockProps) {
+  const styles = STATUS_STYLES[appointment.status];
+  const isCancelled = appointment.status === "cancelled";
+
+  if (mode === "timeline") {
+    return (
+      <button
+        onClick={() => onClick(appointment)}
+        className={cn(
+          "absolute left-0 right-1 overflow-hidden rounded-lg border px-2.5 py-1.5 text-left transition-colors",
+          styles.bg,
+          styles.border,
+        )}
+        style={{ top: `${topPx}px`, height: `${Math.max(heightPx ?? 40, 36)}px` }}
+      >
+        <div className="flex min-w-0 items-start gap-1.5">
+          <span className={cn("mt-1 h-1.5 w-1.5 shrink-0 rounded-full", styles.dot)} />
+          <div className="min-w-0 flex-1">
+            <p
+              className={cn(
+                "truncate text-xs font-semibold leading-tight",
+                isCancelled && "line-through opacity-60",
+              )}
+            >
+              {appointment.clientName}
+            </p>
+            <p
+              className={cn(
+                "truncate text-[10px] leading-tight",
+                styles.text,
+                (heightPx ?? 0) < 50 && "hidden",
+              )}
+            >
+              {appointment.serviceName} · {appointment.startTime.slice(0, 5)}–{appointment.endTime.slice(0, 5)}
+            </p>
+          </div>
+        </div>
+      </button>
+    );
+  }
+
+  // List mode
+  return (
+    <button
+      onClick={() => onClick(appointment)}
+      className={cn(
+        "w-full rounded-xl border px-3 py-3 text-left transition-colors",
+        styles.bg,
+        styles.border,
+      )}
+    >
+      <div className="flex items-center gap-2.5">
+        <span className={cn("h-2 w-2 shrink-0 rounded-full", styles.dot)} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline justify-between gap-2">
+            <p
+              className={cn(
+                "truncate text-sm font-semibold",
+                isCancelled && "line-through opacity-60",
+              )}
+            >
+              {appointment.clientName}
+            </p>
+            <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+              {appointment.startTime.slice(0, 5)}
+            </span>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            {appointment.serviceName} · {appointment.barberDisplayName}
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/components/dashboard/turnos/appointment-modal.tsx
+++ b/components/dashboard/turnos/appointment-modal.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import {
+  X,
+  Phone,
+  Mail,
+  Clock,
+  Scissors,
+  User,
+  Music,
+  Coffee,
+  FileText,
+  CalendarX,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  updateAppointmentStatus,
+  updateAppointmentNotes,
+  rescheduleAppointment,
+} from "@/actions/appointments";
+import type { AppointmentRow } from "@/actions/appointments";
+import type { AppointmentStatus } from "@/lib/db/schema/appointments";
+
+const STATUS_LABELS: Record<AppointmentStatus, string> = {
+  pending: "Pendiente",
+  confirmed: "Confirmado",
+  completed: "Completado",
+  cancelled: "Cancelado",
+  no_show: "No se presentó",
+};
+
+const STATUS_BADGE: Record<AppointmentStatus, string> = {
+  pending: "bg-amber-500/15 text-amber-300 border-amber-500/25",
+  confirmed: "bg-emerald-500/15 text-emerald-300 border-emerald-500/25",
+  completed: "bg-muted/50 text-muted-foreground border-border",
+  cancelled: "bg-red-500/10 text-red-400/70 border-red-500/20",
+  no_show: "bg-red-500/15 text-red-400 border-red-500/30",
+};
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  return d.toLocaleDateString("es-AR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+interface AppointmentModalProps {
+  appointment: AppointmentRow | null;
+  open: boolean;
+  onClose: () => void;
+  onRefresh: () => void;
+}
+
+export function AppointmentModal({
+  appointment,
+  open,
+  onClose,
+  onRefresh,
+}: AppointmentModalProps) {
+  const [notes, setNotes] = useState(appointment?.notes ?? "");
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  // Sync notes when appointment changes
+  useEffect(() => {
+    setNotes(appointment?.notes ?? "");
+    setError(null);
+  }, [appointment]);
+
+  // Close on backdrop click
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === backdropRef.current) onClose();
+  }
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Lock scroll
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  if (!open || !appointment) return null;
+
+  const appt = appointment;
+  const canAct = !["completed", "cancelled", "no_show"].includes(appt.status);
+
+  function act(fn: () => Promise<{ success?: boolean; error?: Record<string, string[]> }>) {
+    setError(null);
+    startTransition(async () => {
+      const result = await fn();
+      if (result?.error?._form?.[0]) {
+        setError(result.error._form[0]);
+      } else {
+        onRefresh();
+        onClose();
+      }
+    });
+  }
+
+  function handleSaveNotes() {
+    act(() => updateAppointmentNotes(appt.id, notes));
+  }
+
+  return (
+    <div
+      ref={backdropRef}
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      onClick={handleBackdropClick}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Panel */}
+      <div
+        className={cn(
+          "relative z-10 w-full max-h-[92dvh] overflow-y-auto rounded-t-2xl border border-border bg-card sm:max-w-md sm:rounded-2xl",
+          "animate-in slide-in-from-bottom-4 duration-200 sm:zoom-in-95",
+        )}
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-border bg-card px-5 py-4">
+          <div className="min-w-0">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Detalle del turno
+            </p>
+            <h2 className="text-lg font-bold tracking-tight">{appt.clientName}</h2>
+            <div className="mt-1 flex items-center gap-2">
+              <span
+                className={cn(
+                  "rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  STATUS_BADGE[appt.status],
+                )}
+              >
+                {STATUS_LABELS[appt.status]}
+              </span>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Cerrar"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="space-y-4 px-5 py-4">
+          {/* Date + time */}
+          <div className="flex items-center gap-2.5 text-sm">
+            <Clock className="h-4 w-4 shrink-0 text-primary" />
+            <span>
+              {formatDate(appt.date)} · {appt.startTime.slice(0, 5)}–{appt.endTime.slice(0, 5)}
+            </span>
+          </div>
+
+          {/* Service */}
+          <div className="flex items-center gap-2.5 text-sm">
+            <Scissors className="h-4 w-4 shrink-0 text-primary" />
+            <span>
+              {appt.serviceName} · {appt.serviceDurationMinutes} min · ${appt.servicePrice}
+            </span>
+          </div>
+
+          {/* Barber */}
+          <div className="flex items-center gap-2.5 text-sm">
+            <User className="h-4 w-4 shrink-0 text-primary" />
+            <span>{appt.barberDisplayName}</span>
+          </div>
+
+          {/* Client contact */}
+          {appt.clientPhone && (
+            <div className="flex items-center gap-2.5 text-sm">
+              <Phone className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <a
+                href={`tel:${appt.clientPhone}`}
+                className="text-primary hover:underline"
+              >
+                {appt.clientPhone}
+              </a>
+            </div>
+          )}
+          {appt.clientEmail && (
+            <div className="flex items-center gap-2.5 text-sm">
+              <Mail className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate text-muted-foreground">{appt.clientEmail}</span>
+            </div>
+          )}
+
+          {/* Preferences */}
+          {appt.clientPreferences &&
+            Object.keys(appt.clientPreferences).length > 0 && (
+              <div className="rounded-xl border border-border/50 bg-muted/20 p-3 space-y-1.5">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                  Preferencias
+                </p>
+                {appt.clientPreferences.music && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <Music className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span>Música: {appt.clientPreferences.music}</span>
+                  </div>
+                )}
+                {appt.clientPreferences.drink && (
+                  <div className="flex items-center gap-2 text-xs">
+                    <Coffee className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span>Bebida: {appt.clientPreferences.drink}</span>
+                  </div>
+                )}
+                {Object.entries(appt.clientPreferences)
+                  .filter(([k]) => k !== "music" && k !== "drink")
+                  .map(([k, v]) => (
+                    <div key={k} className="flex items-center gap-2 text-xs">
+                      <span className="text-muted-foreground capitalize">{k}:</span>
+                      <span>{v}</span>
+                    </div>
+                  ))}
+              </div>
+            )}
+
+          {/* Notes */}
+          <div className="space-y-2">
+            <label className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+              <FileText className="h-3 w-3" />
+              Notas
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Agregar notas internas…"
+              rows={3}
+              className="w-full resize-none rounded-lg border border-border bg-muted/20 px-3 py-2 text-sm placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSaveNotes}
+              disabled={isPending || notes === (appt.notes ?? "")}
+            >
+              Guardar notas
+            </Button>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {error}
+            </p>
+          )}
+
+          {/* Actions */}
+          {canAct && (
+            <div className="border-t border-border pt-3 space-y-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                Acciones
+              </p>
+
+              <div className="flex flex-wrap gap-2">
+                {appt.status === "pending" && (
+                  <Button
+                    size="sm"
+                    onClick={() =>
+                      act(() => updateAppointmentStatus(appt.id, "confirmed"))
+                    }
+                    disabled={isPending}
+                  >
+                    Confirmar
+                  </Button>
+                )}
+                {appt.status === "confirmed" && (
+                  <Button
+                    size="sm"
+                    onClick={() =>
+                      act(() => updateAppointmentStatus(appt.id, "completed"))
+                    }
+                    disabled={isPending}
+                  >
+                    Marcar completado
+                  </Button>
+                )}
+                {(appt.status === "pending" || appt.status === "confirmed") && (
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() =>
+                      act(() => updateAppointmentStatus(appt.id, "cancelled"))
+                    }
+                    disabled={isPending}
+                  >
+                    Cancelar turno
+                  </Button>
+                )}
+              </div>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground"
+                onClick={() => act(() => rescheduleAppointment(appt.id))}
+                disabled={isPending}
+              >
+                <CalendarX className="h-3.5 w-3.5" />
+                Reprogramar (cancelar para que el cliente reserve de nuevo)
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/turnos/date-navigator.tsx
+++ b/components/dashboard/turnos/date-navigator.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { ChevronLeft, ChevronRight, CalendarDays, Clock, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const DAYS_ES = [
+  "domingo", "lunes", "martes", "miércoles",
+  "jueves", "viernes", "sábado",
+];
+const MONTHS_ES = [
+  "enero", "febrero", "marzo", "abril", "mayo", "junio",
+  "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+];
+
+function formatDayLabel(dateStr: string, viewMode: "day" | "week"): string {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+
+  if (viewMode === "day") {
+    const dayName = DAYS_ES[d.getDay()];
+    const monthName = MONTHS_ES[d.getMonth()];
+    const todayStr = todayISO();
+    if (dateStr === todayStr) return `Hoy · ${dayName} ${day} de ${monthName}`;
+    return `${dayName.charAt(0).toUpperCase() + dayName.slice(1)} ${day} de ${monthName}`;
+  }
+
+  // Week: show Mon–Sun range
+  const monday = getWeekStart(dateStr);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  const m1 = MONTHS_ES[monday.getMonth()];
+  const m2 = MONTHS_ES[sunday.getMonth()];
+  if (monday.getMonth() === sunday.getMonth()) {
+    return `${monday.getDate()}–${sunday.getDate()} de ${m1}`;
+  }
+  return `${monday.getDate()} de ${m1} – ${sunday.getDate()} de ${m2}`;
+}
+
+function getWeekStart(dateStr: string): Date {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  const dow = d.getDay();
+  const diff = dow === 0 ? -6 : 1 - dow;
+  d.setDate(d.getDate() + diff);
+  return d;
+}
+
+function todayISO(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+interface DateNavigatorProps {
+  currentDate: string;
+  viewMode: "day" | "week";
+  onNavigate: (direction: -1 | 1) => void;
+  onViewModeChange: (mode: "day" | "week") => void;
+  onToday: () => void;
+  onNewAppointment: () => void;
+  isPending: boolean;
+}
+
+export function DateNavigator({
+  currentDate,
+  viewMode,
+  onNavigate,
+  onViewModeChange,
+  onToday,
+  onNewAppointment,
+  isPending,
+}: DateNavigatorProps) {
+  const today = todayISO();
+  const isToday = viewMode === "day" && currentDate === today;
+
+  return (
+    <div className="border-b border-border bg-background/95 backdrop-blur-sm sticky top-[95px] z-30">
+      <div className="mx-auto max-w-5xl px-4 py-3">
+        {/* Row 1: Label + controls */}
+        <div className="flex items-center justify-between gap-3">
+          {/* Date label */}
+          <div className="min-w-0 flex-1">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {viewMode === "day" ? "Agenda del día" : "Vista semanal"}
+            </p>
+            <h2
+              className={cn(
+                "text-lg font-bold tracking-tight transition-opacity",
+                isPending && "opacity-50",
+              )}
+            >
+              {formatDayLabel(currentDate, viewMode)}
+            </h2>
+          </div>
+
+          {/* Nav buttons */}
+          <div className="flex items-center gap-1">
+            {!isToday && (
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={onToday}
+                className="hidden text-xs sm:flex"
+              >
+                Hoy
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="icon-xs"
+              onClick={() => onNavigate(-1)}
+              disabled={isPending}
+              aria-label="Anterior"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-xs"
+              onClick={() => onNavigate(1)}
+              disabled={isPending}
+              aria-label="Siguiente"
+            >
+              <ChevronRight className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        </div>
+
+        {/* Row 2: View toggle + New button */}
+        <div className="mt-2 flex items-center justify-between gap-2">
+          {/* Day/Week toggle */}
+          <div className="flex rounded-lg border border-border bg-muted/30 p-0.5">
+            <button
+              onClick={() => onViewModeChange("day")}
+              className={cn(
+                "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                viewMode === "day"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Clock className="h-3 w-3" />
+              Día
+            </button>
+            <button
+              onClick={() => onViewModeChange("week")}
+              className={cn(
+                "flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                viewMode === "week"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <CalendarDays className="h-3 w-3" />
+              Semana
+            </button>
+          </div>
+
+          {/* New appointment */}
+          <Button size="sm" onClick={onNewAppointment}>
+            <Plus className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Nuevo turno</span>
+            <span className="sm:hidden">Nuevo</span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/turnos/day-timeline.tsx
+++ b/components/dashboard/turnos/day-timeline.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { CalendarClock } from "lucide-react";
+import { AppointmentBlock } from "./appointment-block";
+import type { AppointmentRow } from "@/actions/appointments";
+
+type OpeningHours = Record<
+  string,
+  { closed?: boolean; open?: string; close?: string }
+>;
+
+const WEEK_DAYS = [
+  "sunday", "monday", "tuesday", "wednesday",
+  "thursday", "friday", "saturday",
+] as const;
+
+const PX_PER_MINUTE = 1.5;
+const MIN_HOUR_HEIGHT = PX_PER_MINUTE * 60; // 90px
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function getDayBounds(
+  dateStr: string,
+  openingHours: OpeningHours | null,
+): { openMin: number; closeMin: number } {
+  const [year, month, day] = dateStr.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  const dayKey = WEEK_DAYS[d.getDay()];
+  const dayHours = openingHours?.[dayKey];
+
+  if (dayHours && !dayHours.closed && dayHours.open && dayHours.close) {
+    return {
+      openMin: timeToMinutes(dayHours.open),
+      closeMin: timeToMinutes(dayHours.close),
+    };
+  }
+
+  // Default: 08:00 – 20:00
+  return { openMin: 8 * 60, closeMin: 20 * 60 };
+}
+
+function buildHourLabels(openMin: number, closeMin: number): string[] {
+  const labels: string[] = [];
+  const startHour = Math.floor(openMin / 60);
+  const endHour = Math.ceil(closeMin / 60);
+  for (let h = startHour; h <= endHour; h++) {
+    labels.push(`${String(h).padStart(2, "0")}:00`);
+  }
+  return labels;
+}
+
+interface DayTimelineProps {
+  date: string;
+  appointments: AppointmentRow[];
+  openingHours: OpeningHours | null;
+  onAppointmentClick: (appointment: AppointmentRow) => void;
+}
+
+export function DayTimeline({
+  date,
+  appointments,
+  openingHours,
+  onAppointmentClick,
+}: DayTimelineProps) {
+  const { openMin, closeMin } = getDayBounds(date, openingHours);
+  const totalMinutes = closeMin - openMin;
+  const containerHeight = totalMinutes * PX_PER_MINUTE;
+  const hourLabels = buildHourLabels(openMin, closeMin);
+
+  if (appointments.length === 0) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-8">
+        {/* Empty timeline with hour lines */}
+        <div className="relative flex gap-3">
+          {/* Hour labels */}
+          <div
+            className="relative w-12 shrink-0 select-none"
+            style={{ height: `${containerHeight}px` }}
+          >
+            {hourLabels.map((label, i) => (
+              <span
+                key={label}
+                className="absolute right-0 text-[10px] tabular-nums text-muted-foreground/50 -translate-y-2"
+                style={{ top: `${i * MIN_HOUR_HEIGHT}px` }}
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+
+          {/* Grid area */}
+          <div
+            className="relative flex-1 rounded-xl border border-border/50"
+            style={{ height: `${containerHeight}px` }}
+          >
+            {hourLabels.map((_, i) => (
+              <div
+                key={i}
+                className="absolute left-0 right-0 border-t border-border/30"
+                style={{ top: `${i * MIN_HOUR_HEIGHT}px` }}
+              />
+            ))}
+
+            {/* Empty state overlay */}
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+              <CalendarClock className="h-8 w-8 text-muted-foreground/20" />
+              <p className="mt-3 text-sm font-medium text-muted-foreground/50">
+                Sin turnos para este día
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-4">
+      <div className="relative flex gap-3">
+        {/* Hour labels */}
+        <div
+          className="relative w-12 shrink-0 select-none"
+          style={{ height: `${containerHeight}px` }}
+        >
+          {hourLabels.map((label, i) => (
+            <span
+              key={label}
+              className="absolute right-0 text-[10px] tabular-nums text-muted-foreground/50 -translate-y-2"
+              style={{ top: `${i * MIN_HOUR_HEIGHT}px` }}
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+
+        {/* Timeline grid + appointments */}
+        <div
+          className="relative flex-1"
+          style={{ height: `${containerHeight}px` }}
+        >
+          {/* Hour grid lines */}
+          {hourLabels.map((_, i) => (
+            <div
+              key={i}
+              className="absolute left-0 right-0 border-t border-border/30"
+              style={{ top: `${i * MIN_HOUR_HEIGHT}px` }}
+            />
+          ))}
+
+          {/* Appointment blocks */}
+          {appointments.map((appt) => {
+            const apptStart = timeToMinutes(appt.startTime);
+            const apptEnd = timeToMinutes(appt.endTime);
+            const topPx = (apptStart - openMin) * PX_PER_MINUTE;
+            const heightPx = (apptEnd - apptStart) * PX_PER_MINUTE;
+
+            // Clamp to visible area
+            if (apptStart >= closeMin || apptEnd <= openMin) return null;
+
+            return (
+              <AppointmentBlock
+                key={appt.id}
+                appointment={appt}
+                onClick={onAppointmentClick}
+                mode="timeline"
+                topPx={Math.max(topPx, 0)}
+                heightPx={heightPx}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/turnos/new-appointment-modal.tsx
+++ b/components/dashboard/turnos/new-appointment-modal.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState, useTransition } from "react";
+import { X, Search, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  createManualAppointment,
+  searchClients,
+} from "@/actions/appointments";
+import type { BarberOption, ClientSearchResult, ServiceOption } from "@/actions/appointments";
+import { getAvailableSlots as getSlots } from "@/actions/booking";
+
+interface NewAppointmentModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  barbers: BarberOption[];
+  services: ServiceOption[];
+  userRole: "owner" | "barber";
+  ownBarberId: string | null;
+  tenantId: string;
+}
+
+type FieldErrors = Record<string, string[] | undefined>;
+
+const inputClass =
+  "w-full rounded-lg border border-border bg-muted/20 px-3 py-2 text-sm placeholder:text-muted-foreground/50 focus:border-primary/50 focus:outline-none focus:ring-1 focus:ring-primary/30 disabled:opacity-50";
+
+const labelClass =
+  "block text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground mb-1";
+
+export function NewAppointmentModal({
+  open,
+  onClose,
+  onSuccess,
+  barbers,
+  services,
+  userRole,
+  ownBarberId,
+  tenantId,
+}: NewAppointmentModalProps) {
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  // Client search
+  const [clientQuery, setClientQuery] = useState("");
+  const [clientResults, setClientResults] = useState<ClientSearchResult[]>([]);
+  const [selectedClient, setSelectedClient] = useState<ClientSearchResult | null>(null);
+  const [clientName, setClientName] = useState("");
+  const [clientPhone, setClientPhone] = useState("");
+  const [isSearching, startSearch] = useTransition();
+
+  // Form fields
+  const [selectedBarberId, setSelectedBarberId] = useState(
+    userRole === "barber" ? (ownBarberId ?? "") : (barbers[0]?.id ?? ""),
+  );
+  const [selectedServiceId, setSelectedServiceId] = useState(services[0]?.id ?? "");
+  const [date, setDate] = useState(todayISO());
+  const [startTime, setStartTime] = useState("");
+  const [availableSlots, setAvailableSlots] = useState<string[]>([]);
+  const [loadingSlots, setLoadingSlots] = useState(false);
+
+  const [state, formAction, isPending] = useActionState(
+    createManualAppointment,
+    null,
+  );
+
+  const errors: FieldErrors = (state?.error as FieldErrors) ?? {};
+
+  // Close on success
+  useEffect(() => {
+    if (state?.success) {
+      onSuccess();
+      onClose();
+    }
+  }, [state?.success, onSuccess, onClose]);
+
+  // Reset on open
+  useEffect(() => {
+    if (open) {
+      setClientQuery("");
+      setClientResults([]);
+      setSelectedClient(null);
+      setClientName("");
+      setClientPhone("");
+      setStartTime("");
+      setAvailableSlots([]);
+    }
+  }, [open]);
+
+  // Fetch available slots when barber/service/date changes
+  useEffect(() => {
+    if (!selectedBarberId || !selectedServiceId || !date) return;
+    const service = services.find((s) => s.id === selectedServiceId);
+    if (!service) return;
+
+    setLoadingSlots(true);
+    setStartTime("");
+    getSlots(tenantId, selectedBarberId, date, service.durationMinutes)
+      .then((slots) => {
+        setAvailableSlots(slots);
+        if (slots.length > 0) setStartTime(slots[0]);
+      })
+      .finally(() => setLoadingSlots(false));
+  }, [selectedBarberId, selectedServiceId, date, tenantId, services]);
+
+  // Client search debounce
+  useEffect(() => {
+    if (clientQuery.length < 2) {
+      setClientResults([]);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      startSearch(async () => {
+        const results = await searchClients(clientQuery);
+        setClientResults(results);
+      });
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [clientQuery]);
+
+  function handleSelectClient(client: ClientSearchResult) {
+    setSelectedClient(client);
+    setClientName(client.name);
+    setClientPhone(client.phone ?? "");
+    setClientQuery("");
+    setClientResults([]);
+  }
+
+  function handleClearClient() {
+    setSelectedClient(null);
+    setClientName("");
+    setClientPhone("");
+  }
+
+  // Close on backdrop
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === backdropRef.current) onClose();
+  }
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Lock scroll
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={backdropRef}
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      onClick={handleBackdropClick}
+    >
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      <div
+        className={cn(
+          "relative z-10 w-full max-h-[92dvh] overflow-y-auto rounded-t-2xl border border-border bg-card sm:max-w-md sm:rounded-2xl",
+          "animate-in slide-in-from-bottom-4 duration-200 sm:zoom-in-95",
+        )}
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-card px-5 py-4">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Turnos
+            </p>
+            <h2 className="text-lg font-bold tracking-tight">Nuevo turno</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Cerrar"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Form */}
+        <form action={formAction} className="space-y-4 px-5 py-4">
+          {/* Hidden fields */}
+          <input type="hidden" name="clientId" value={selectedClient?.id ?? ""} />
+          <input type="hidden" name="barberId" value={selectedBarberId} />
+          <input type="hidden" name="serviceId" value={selectedServiceId} />
+          <input type="hidden" name="date" value={date} />
+          <input type="hidden" name="startTime" value={startTime} />
+
+          {/* Client search */}
+          <div>
+            <label className={labelClass}>Cliente</label>
+
+            {selectedClient ? (
+              <div className="flex items-center justify-between rounded-lg border border-emerald-500/25 bg-emerald-500/8 px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium">{selectedClient.name}</p>
+                  {selectedClient.phone && (
+                    <p className="text-xs text-muted-foreground">{selectedClient.phone}</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={handleClearClient}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/50" />
+                  <input
+                    type="text"
+                    value={clientQuery}
+                    onChange={(e) => setClientQuery(e.target.value)}
+                    placeholder="Buscar por nombre o teléfono…"
+                    className={cn(inputClass, "pl-8")}
+                  />
+                  {isSearching && (
+                    <Loader2 className="absolute right-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 animate-spin text-muted-foreground/50" />
+                  )}
+                </div>
+
+                {clientResults.length > 0 && (
+                  <div className="absolute z-20 mt-1 w-full rounded-lg border border-border bg-card shadow-lg">
+                    {clientResults.map((c) => (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={() => handleSelectClient(c)}
+                        className="w-full px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted first:rounded-t-lg last:rounded-b-lg"
+                      >
+                        <p className="font-medium">{c.name}</p>
+                        {c.phone && (
+                          <p className="text-xs text-muted-foreground">{c.phone}</p>
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Client name (new client) */}
+          {!selectedClient && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>Nombre *</label>
+                <input
+                  type="text"
+                  name="clientName"
+                  value={clientName}
+                  onChange={(e) => setClientName(e.target.value)}
+                  placeholder="Nombre del cliente"
+                  className={inputClass}
+                  required
+                />
+                {errors.clientName && (
+                  <p className="mt-1 text-xs text-destructive">{errors.clientName[0]}</p>
+                )}
+              </div>
+              <div>
+                <label className={labelClass}>Teléfono</label>
+                <input
+                  type="tel"
+                  name="clientPhone"
+                  value={clientPhone}
+                  onChange={(e) => setClientPhone(e.target.value)}
+                  placeholder="+54 11…"
+                  className={inputClass}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Hidden name/phone when client is selected */}
+          {selectedClient && (
+            <>
+              <input type="hidden" name="clientName" value={selectedClient.name} />
+              <input type="hidden" name="clientPhone" value={selectedClient.phone ?? ""} />
+            </>
+          )}
+
+          {/* Barber */}
+          {userRole === "owner" && (
+            <div>
+              <label className={labelClass}>Barbero *</label>
+              <select
+                value={selectedBarberId}
+                onChange={(e) => setSelectedBarberId(e.target.value)}
+                className={inputClass}
+              >
+                {barbers.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.displayName}
+                  </option>
+                ))}
+              </select>
+              {errors.barberId && (
+                <p className="mt-1 text-xs text-destructive">{errors.barberId[0]}</p>
+              )}
+            </div>
+          )}
+
+          {/* Service */}
+          <div>
+            <label className={labelClass}>Servicio *</label>
+            <select
+              value={selectedServiceId}
+              onChange={(e) => setSelectedServiceId(e.target.value)}
+              className={inputClass}
+            >
+              {services.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name} · {s.durationMinutes} min · ${s.price}
+                </option>
+              ))}
+            </select>
+            {errors.serviceId && (
+              <p className="mt-1 text-xs text-destructive">{errors.serviceId[0]}</p>
+            )}
+          </div>
+
+          {/* Date */}
+          <div>
+            <label className={labelClass}>Fecha *</label>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              min={todayISO()}
+              className={inputClass}
+            />
+            {errors.date && (
+              <p className="mt-1 text-xs text-destructive">{errors.date[0]}</p>
+            )}
+          </div>
+
+          {/* Time slot */}
+          <div>
+            <label className={labelClass}>Horario *</label>
+            {loadingSlots ? (
+              <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/20 px-3 py-2.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">Cargando horarios…</span>
+              </div>
+            ) : availableSlots.length === 0 ? (
+              <p className="rounded-lg border border-border bg-muted/20 px-3 py-2.5 text-sm text-muted-foreground">
+                Sin horarios disponibles para este día
+              </p>
+            ) : (
+              <div className="grid grid-cols-4 gap-1.5 sm:grid-cols-5">
+                {availableSlots.map((slot) => (
+                  <button
+                    key={slot}
+                    type="button"
+                    onClick={() => setStartTime(slot)}
+                    className={cn(
+                      "rounded-lg border px-2 py-1.5 text-xs font-medium tabular-nums transition-colors",
+                      startTime === slot
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-muted/20 hover:border-primary/40 hover:bg-muted/50",
+                    )}
+                  >
+                    {slot}
+                  </button>
+                ))}
+              </div>
+            )}
+            {errors.startTime && (
+              <p className="mt-1 text-xs text-destructive">{errors.startTime[0]}</p>
+            )}
+          </div>
+
+          {/* Global error */}
+          {errors._form && (
+            <p className="rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {errors._form[0]}
+            </p>
+          )}
+
+          {/* Submit */}
+          <div className="flex justify-end gap-2 border-t border-border pt-3">
+            <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={
+                isPending ||
+                !startTime ||
+                (!selectedClient && !clientName.trim())
+              }
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Creando…
+                </>
+              ) : (
+                "Crear turno"
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function todayISO(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}

--- a/components/dashboard/turnos/week-grid.tsx
+++ b/components/dashboard/turnos/week-grid.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AppointmentBlock } from "./appointment-block";
+import type { AppointmentRow } from "@/actions/appointments";
+
+const DAY_NAMES_ES = [
+  "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom",
+];
+
+const MONTHS_ES = [
+  "ene", "feb", "mar", "abr", "may", "jun",
+  "jul", "ago", "sep", "oct", "nov", "dic",
+];
+
+function getWeekDays(currentDate: string): string[] {
+  const [year, month, day] = currentDate.split("-").map(Number);
+  const d = new Date(year, month - 1, day);
+  const dow = d.getDay();
+  const diff = dow === 0 ? -6 : 1 - dow;
+  const monday = new Date(d);
+  monday.setDate(d.getDate() + diff);
+
+  return Array.from({ length: 7 }, (_, i) => {
+    const date = new Date(monday);
+    date.setDate(monday.getDate() + i);
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  });
+}
+
+function todayISO(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function formatDayHeader(dateStr: string): { short: string; num: number; month: string } {
+  const [, month, day] = dateStr.split("-").map(Number);
+  const [year, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(year, m - 1, d);
+  const dow = date.getDay();
+  const idx = dow === 0 ? 6 : dow - 1; // Monday=0, Sunday=6
+  return {
+    short: DAY_NAMES_ES[idx],
+    num: day,
+    month: MONTHS_ES[month - 1],
+  };
+}
+
+// Mobile: collapsible day row
+function MobileDayRow({
+  dateStr,
+  appointments,
+  onAppointmentClick,
+  isToday,
+}: {
+  dateStr: string;
+  appointments: AppointmentRow[];
+  onAppointmentClick: (a: AppointmentRow) => void;
+  isToday: boolean;
+}) {
+  const [open, setOpen] = useState(isToday);
+  const { short, num, month } = formatDayHeader(dateStr);
+
+  return (
+    <div className="border-b border-border/50 last:border-0">
+      <button
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/30"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <div
+          className={cn(
+            "flex h-9 w-9 shrink-0 flex-col items-center justify-center rounded-lg text-center",
+            isToday ? "bg-primary text-primary-foreground" : "bg-muted/40",
+          )}
+        >
+          <span className="text-[9px] font-semibold uppercase leading-none tracking-wide">
+            {short}
+          </span>
+          <span className="text-sm font-bold leading-tight tabular-nums">
+            {num}
+          </span>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">
+            {short} {num} de {month}
+            {isToday && (
+              <span className="ml-1.5 text-[10px] font-semibold text-primary">
+                hoy
+              </span>
+            )}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {appointments.length === 0
+              ? "Sin turnos"
+              : `${appointments.length} ${appointments.length === 1 ? "turno" : "turnos"}`}
+          </p>
+        </div>
+
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="space-y-1.5 px-4 pb-3">
+          {appointments.length === 0 ? (
+            <p className="py-2 text-xs text-muted-foreground/60">
+              No hay turnos para este día
+            </p>
+          ) : (
+            appointments.map((appt) => (
+              <AppointmentBlock
+                key={appt.id}
+                appointment={appt}
+                onClick={onAppointmentClick}
+                mode="list"
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface WeekGridProps {
+  currentDate: string;
+  appointments: AppointmentRow[];
+  onAppointmentClick: (appointment: AppointmentRow) => void;
+}
+
+export function WeekGrid({
+  currentDate,
+  appointments,
+  onAppointmentClick,
+}: WeekGridProps) {
+  const weekDays = getWeekDays(currentDate);
+  const today = todayISO();
+
+  const byDay: Record<string, AppointmentRow[]> = {};
+  for (const day of weekDays) byDay[day] = [];
+  for (const appt of appointments) {
+    if (byDay[appt.date]) byDay[appt.date].push(appt);
+  }
+
+  return (
+    <>
+      {/* Mobile: collapsible list */}
+      <div className="md:hidden">
+        {weekDays.map((dateStr) => (
+          <MobileDayRow
+            key={dateStr}
+            dateStr={dateStr}
+            appointments={byDay[dateStr]}
+            onAppointmentClick={onAppointmentClick}
+            isToday={dateStr === today}
+          />
+        ))}
+      </div>
+
+      {/* Desktop: 7-column grid */}
+      <div className="mx-auto hidden max-w-5xl px-4 py-4 md:block">
+        {/* Day headers */}
+        <div className="grid grid-cols-7 gap-1 mb-2">
+          {weekDays.map((dateStr) => {
+            const { short, num, month } = formatDayHeader(dateStr);
+            const isToday = dateStr === today;
+            return (
+              <div key={dateStr} className="text-center">
+                <div
+                  className={cn(
+                    "mx-auto flex h-9 w-9 flex-col items-center justify-center rounded-lg",
+                    isToday ? "bg-primary text-primary-foreground" : "",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "text-[9px] font-semibold uppercase leading-none tracking-wide",
+                      isToday ? "text-primary-foreground/80" : "text-muted-foreground",
+                    )}
+                  >
+                    {short}
+                  </span>
+                  <span className="text-sm font-bold tabular-nums leading-tight">
+                    {num}
+                  </span>
+                </div>
+                <p
+                  className={cn(
+                    "mt-0.5 text-[9px]",
+                    isToday ? "text-primary font-semibold" : "text-muted-foreground/50",
+                  )}
+                >
+                  {month}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Appointment columns */}
+        <div className="grid grid-cols-7 gap-1">
+          {weekDays.map((dateStr) => {
+            const dayAppts = byDay[dateStr];
+            const isToday = dateStr === today;
+            return (
+              <div
+                key={dateStr}
+                className={cn(
+                  "min-h-[120px] rounded-xl border p-1.5 space-y-1",
+                  isToday ? "border-primary/20 bg-primary/3" : "border-border/50 bg-card/30",
+                )}
+              >
+                {dayAppts.length === 0 ? (
+                  <p className="py-2 text-center text-[10px] text-muted-foreground/30">
+                    —
+                  </p>
+                ) : (
+                  dayAppts.map((appt) => (
+                    <button
+                      key={appt.id}
+                      onClick={() => onAppointmentClick(appt)}
+                      className={cn(
+                        "w-full rounded-lg border px-1.5 py-1 text-left text-[10px] leading-tight transition-colors",
+                        appt.status === "pending" && "border-amber-500/20 bg-amber-500/8 hover:bg-amber-500/12",
+                        appt.status === "confirmed" && "border-emerald-500/20 bg-emerald-500/8 hover:bg-emerald-500/12",
+                        appt.status === "completed" && "border-border bg-muted/30 hover:bg-muted/50",
+                        (appt.status === "cancelled" || appt.status === "no_show") && "border-red-500/20 bg-red-500/8 hover:bg-red-500/12",
+                      )}
+                    >
+                      <p className="truncate font-semibold">{appt.clientName}</p>
+                      <p className="truncate text-muted-foreground">
+                        {appt.startTime.slice(0, 5)}
+                      </p>
+                    </button>
+                  ))
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## feat: sistema de turnos /dashboard/turnos

### Qué incluye
- Vista día: timeline visual con bloques posicionados por tiempo (1.5px/min)
- Vista semana: grilla 7 días desktop / lista colapsable mobile
- Navegación día/semana sin recarga (useTransition + server action)
- Modal de detalle: preferencias del cliente, notas editables, acciones por status
- Modal nuevo turno manual: búsqueda de cliente, slots en tiempo real
- Filtro por barbero visible solo para owner
- Autorización por rol: barber solo ve/modifica sus propios turnos

### Fixes críticos aplicados
- Auth bypass con ownBarberId null — 4 guards en mutaciones
- clientId validado contra tenantId antes de usar
- DateNavigator offset corregido (top-[95px])
- Backdrop click cierra modales correctamente