### PR TITLE
fix: overlap detection, no_show reschedule block, filter cancelled slots

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,7 @@
 - /onboarding/step-2 → servicios (opcional)
 - /onboarding/step-3 → barberos (opcional)
 - /dashboard → panel principal del dueño (protegida)
+- /dashboard/turnos → sistema de turnos (protegida)
 - /[slug] → landing pública de la barbería (no requiere auth)
 - /[slug]/reservar → wizard de reserva de 4 pasos (no requiere auth)
 - /[slug]/reservar/confirmacion → página de éxito con searchParams
@@ -48,6 +49,12 @@
 - Conflict check fuera de la transacción — dentro solo van upsert de client e insert de appointment
 - visitCount se incrementa en cada booking por diseño
 - Confirmación recibe datos via searchParams, sin query a DB — guard redirige a /reservar si faltan params
+- getAuthContext() en actions/appointments.ts verifica sesión + rol + ownBarberId del barbero
+- Barber con ownBarberId null → acceso denegado inmediatamente (no bypassa autorización)
+- clientId en createManualAppointment validado contra tenantId antes de usar
+- Timeline visual usa posicionamiento absoluto 1.5px/minuto — default 08:00-20:00 si openingHours es null
+- Modales implementados nativamente sin librería externa (backdrop + Escape listener)
+- getAvailableSlots reutilizado desde actions/booking.ts en el modal de nuevo turno
 
 ## Estado de Supabase
 - Bucket "logos" creado (público)
@@ -63,9 +70,11 @@
 - ✅ Dashboard principal con botón "Ver mi landing"
 - ✅ Landing pública /[slug] (7 secciones + 404 personalizada + SEO dinámico)
 - ✅ Wizard de reserva /[slug]/reservar (4 pasos + reconocimiento cliente recurrente)
+- ✅ Sistema de turnos /dashboard/turnos (timeline día + grilla semana + modales)
 
 ## Próximas features
-- [ ] Sistema de turnos (calendario en dashboard) ← SIGUIENTE
-- [ ] CRM de clientes
+- [ ] CRM de clientes ← SIGUIENTE
 - [ ] Notificaciones (WhatsApp/Twilio)
 - [ ] Gestión de barberos y servicios en dashboard
+- [ ] Bloqueo de slots (tabla blocked_slots ya existe en schema)
+- [ ] Rol barber completo (UI para vincular cuenta a registro de barbers)

--- a/actions/appointments.ts
+++ b/actions/appointments.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { and, eq, gte, ilike, lte, notInArray, or } from "drizzle-orm";
+import { and, eq, gt, gte, ilike, lt, lte, notInArray, or } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import {
@@ -329,7 +329,7 @@ export async function rescheduleAppointment(
     return { error: { _form: ["No autorizado"] } };
   }
 
-  if (appt.status === "completed" || appt.status === "cancelled") {
+  if (appt.status === "completed" || appt.status === "cancelled" || appt.status === "no_show") {
     return { error: { _form: ["No se puede reprogramar este turno"] } };
   }
 
@@ -439,7 +439,8 @@ export async function createManualAppointment(
         eq(appointments.tenantId, tenantId),
         eq(appointments.barberId, data.barberId),
         eq(appointments.date, data.date),
-        eq(appointments.startTime, data.startTime),
+        gt(appointments.endTime, data.startTime),
+        lt(appointments.startTime, endTime),
         notInArray(appointments.status, ["cancelled", "no_show"]),
       ),
     )

--- a/actions/booking.ts
+++ b/actions/booking.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq, and, notInArray } from "drizzle-orm";
+import { eq, and, notInArray, gt, lt } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import { db } from "@/lib/db";
 import {
@@ -161,6 +161,7 @@ export async function getAvailableSlots(
           eq(appointments.tenantId, tenantId),
           eq(appointments.barberId, effectiveBarberId),
           eq(appointments.date, date),
+          notInArray(appointments.status, ["cancelled", "no_show"]),
         ),
       ),
     db
@@ -285,7 +286,8 @@ export async function createAppointment(
         eq(appointments.tenantId, tenantId),
         eq(appointments.barberId, resolvedBarberId),
         eq(appointments.date, date),
-        eq(appointments.startTime, startTime),
+        gt(appointments.endTime, startTime),
+        lt(appointments.startTime, endTime),
         notInArray(appointments.status, ["cancelled", "no_show"]),
       ),
     )


### PR DESCRIPTION
## fix: detección de conflictos y guards de status

### Qué incluye
- Conflict check reemplazado por detección de solapamiento real 
  (gt/lt en lugar de eq exacto) en createAppointment y 
  createManualAppointment
- no_show bloqueado server-side en rescheduleAppointment
- getAvailableSlots excluye appointments cancelled y no_show 
  al calcular slots disponibles

### Issues cerrados
Closes #18
Closes #25
Closes #26