### PR TITLE
fix: preserve notes on reschedule and show barber bio in booking wizard

### DIFF
--- a/actions/appointments.ts
+++ b/actions/appointments.ts
@@ -310,6 +310,7 @@ export async function rescheduleAppointment(
       id: appointments.id,
       barberId: appointments.barberId,
       status: appointments.status,
+      notes: appointments.notes,
     })
     .from(appointments)
     .where(
@@ -333,11 +334,16 @@ export async function rescheduleAppointment(
     return { error: { _form: ["No se puede reprogramar este turno"] } };
   }
 
+  const rescheduleNote = "Reprogramado — cliente debe reservar de nuevo";
+  const mergedNotes = appt.notes
+    ? `${rescheduleNote}\n\n${appt.notes}`
+    : rescheduleNote;
+
   await db
     .update(appointments)
     .set({
       status: "cancelled",
-      notes: "Reprogramado — cliente debe reservar de nuevo",
+      notes: mergedNotes,
     })
     .where(eq(appointments.id, appointmentId));
 

--- a/components/booking/booking-wizard.tsx
+++ b/components/booking/booking-wizard.tsx
@@ -330,6 +330,11 @@ export default function BookingWizard({
               <span className="line-clamp-2 text-[11px] font-medium leading-tight text-foreground">
                 {barber.displayName}
               </span>
+              {barber.bio && (
+                <span className="line-clamp-2 text-[10px] leading-tight text-muted-foreground">
+                  {barber.bio}
+                </span>
+              )}
               {selectedBarberId === barber.id && (
                 <Check className="h-3.5 w-3.5 text-primary" />
               )}


### PR DESCRIPTION
## fix: notas al reprogramar y bio del barbero en wizard

### Qué incluye
- rescheduleAppointment antepone la nota de reprogramación 
  preservando notas internas previas del barbero
- Bio del barbero visible en Step 2 del wizard de reserva,
  debajo del nombre — humaniza la elección del barbero

### Issues cerrados
Closes #24
Closes #20