### PR TITLE
perf: deduplicate tenant and profile queries with React.cache and pre…

### DIFF
--- a/actions/appointments.ts
+++ b/actions/appointments.ts
@@ -64,7 +64,7 @@ function minutesToTime(minutes: number): string {
   return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
 }
 
-type AuthContext = {
+export type AuthContext = {
   userId: string;
   tenantId: string;
   role: "owner" | "barber";
@@ -152,8 +152,9 @@ async function fetchRows(
 export async function getAppointmentsForDay(
   date: string,
   filterBarberId?: string,
+  preloadedCtx?: AuthContext,
 ): Promise<AppointmentRow[]> {
-  const ctx = await getAuthContext();
+  const ctx = preloadedCtx ?? (await getAuthContext());
   if (!ctx) return [];
 
   const { tenantId, role, ownBarberId } = ctx;

--- a/app/(dashboard)/dashboard/turnos/page.tsx
+++ b/app/(dashboard)/dashboard/turnos/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/db/schema";
 import { getAppointmentsForDay } from "@/actions/appointments";
 import { AgendaView } from "@/components/dashboard/turnos/agenda-view";
-import type { BarberOption, ServiceOption } from "@/actions/appointments";
+import type { BarberOption, ServiceOption, AuthContext } from "@/actions/appointments";
 
 export const metadata = {
   title: "Turnos — BarberSaaS",
@@ -57,6 +57,13 @@ export default async function TurnosPage() {
     ownBarberId = barber?.id ?? null;
   }
 
+  const preloadedCtx: AuthContext = {
+    userId: user.id,
+    tenantId,
+    role: userRole,
+    ownBarberId,
+  };
+
   const [tenant, tenantBarbers, tenantServices, initialAppointments] =
     await Promise.all([
       db.query.tenants.findFirst({
@@ -88,7 +95,7 @@ export default async function TurnosPage() {
           ),
         )
         .orderBy(servicesTable.name),
-      getAppointmentsForDay(today),
+      getAppointmentsForDay(today, undefined, preloadedCtx),
     ]);
 
   const barbers: BarberOption[] = tenantBarbers;

--- a/app/[slug]/reservar/page.tsx
+++ b/app/[slug]/reservar/page.tsx
@@ -1,3 +1,5 @@
+import { cache } from "react";
+import { unstable_cache } from "next/cache";
 import { notFound } from "next/navigation";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
@@ -20,44 +22,56 @@ const openingHoursSchema = z.record(
   }),
 );
 
+const fetchReservarData = unstable_cache(
+  async (slug: string) => {
+    const tenant = await db.query.tenants.findFirst({
+      where: eq(tenants.slug, slug),
+    });
+    if (!tenant) return null;
+
+    const [barberList, serviceList] = await Promise.all([
+      db
+        .select({
+          id: barbers.id,
+          displayName: barbers.displayName,
+          bio: barbers.bio,
+          avatarUrl: profiles.avatarUrl,
+        })
+        .from(barbers)
+        .leftJoin(profiles, eq(barbers.profileId, profiles.id))
+        .where(and(eq(barbers.tenantId, tenant.id), eq(barbers.isActive, true))),
+      db
+        .select()
+        .from(services)
+        .where(
+          and(eq(services.tenantId, tenant.id), eq(services.isActive, true)),
+        ),
+    ]);
+
+    return { tenant, barberList, serviceList };
+  },
+  ["tenant-reservar"],
+  { revalidate: 60 },
+);
+
+const getReservarData = cache(fetchReservarData);
+
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
-  const tenant = await db.query.tenants.findFirst({
-    where: eq(tenants.slug, slug),
-    columns: { name: true },
-  });
-  if (!tenant) return {};
-  return { title: `Reservar turno | ${tenant.name}` };
+  const data = await getReservarData(slug);
+  if (!data) return {};
+  return { title: `Reservar turno | ${data.tenant.name}` };
 }
 
 export default async function ReservarPage({ params }: PageProps) {
   const { slug } = await params;
 
-  const tenant = await db.query.tenants.findFirst({
-    where: eq(tenants.slug, slug),
-  });
-  if (!tenant) notFound();
+  const data = await getReservarData(slug);
+  if (!data) notFound();
 
-  const [barberList, serviceList] = await Promise.all([
-    db
-      .select({
-        id: barbers.id,
-        displayName: barbers.displayName,
-        bio: barbers.bio,
-        avatarUrl: profiles.avatarUrl,
-      })
-      .from(barbers)
-      .leftJoin(profiles, eq(barbers.profileId, profiles.id))
-      .where(and(eq(barbers.tenantId, tenant.id), eq(barbers.isActive, true))),
-    db
-      .select()
-      .from(services)
-      .where(
-        and(eq(services.tenantId, tenant.id), eq(services.isActive, true)),
-      ),
-  ]);
+  const { tenant, barberList, serviceList } = data;
 
   const parsedHours = openingHoursSchema.safeParse(tenant.openingHours);
   const openingHours = parsedHours.success ? parsedHours.data : null;


### PR DESCRIPTION
## perf: deduplicar queries de tenant y profile

### Qué incluye
- reservar/page.tsx: React.cache() + unstable_cache(revalidate: 60)
  evitan doble query al tenant entre generateMetadata y ReservarPage
- /dashboard/turnos: AuthContext exportado, getAppointmentsForDay 
  acepta preloadedCtx opcional — TurnosPage pasa el profile ya 
  fetcheado evitando segunda query a profiles

### Issues cerrados
Closes #17
Closes #27