### PR TITLE
feat: client CRM with list, filters, search and detail page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,8 @@
 - /onboarding/step-3 → barberos (opcional)
 - /dashboard → panel principal del dueño (protegida)
 - /dashboard/turnos → sistema de turnos (protegida)
+- /dashboard/clientes → lista de clientes con search y filtros (protegida)
+- /dashboard/clientes/[id] → detalle del cliente (protegida)
 - /[slug] → landing pública de la barbería (no requiere auth)
 - /[slug]/reservar → wizard de reserva de 4 pasos (no requiere auth)
 - /[slug]/reservar/confirmacion → página de éxito con searchParams
@@ -61,6 +63,14 @@
 - rescheduleAppointment bloquea status completed, cancelled y no_show server-side
 - AuthContext exportado — getAppointmentsForDay acepta preloadedCtx opcional para evitar doble query
 - reservar/page.tsx usa React.cache() + unstable_cache(revalidate: 60) igual que la landing
+- "use server" prohíbe exportar valores no-async — PAGE_SIZE es const privado en actions/clients.ts
+- parseDateSafe(dateStr) en client-utils.ts → new Date("YYYY-MM-DT12:00:00") evita timezone bug en Argentina (UTC-3)
+- parseDateSafe solo aplica a campos date de Drizzle (mode: "string") — timestamps ISO usan new Date() directo
+- Paginación con "Ver más" (append) — page validado con Math.max(1, Math.floor(page)) para evitar OFFSET negativo
+- onBlur save en PreferencesEditor y NotesEditor — merge de preferences no sobreescribe keys no enviadas
+- Todas las queries de mutación del CRM tienen tenantId en el WHERE como defensa en profundidad
+- Regla de categorías: visitCount === 1 → Nuevo, 2-5 → Regular, ≥ 6 → VIP (en client-utils.ts)
+- Link "Nuevo turno" abre /{slug}/reservar?phone={phone} — booking wizard ya soporta ese searchParam
 
 ## Estado de Supabase
 - Bucket "logos" creado (público)
@@ -77,14 +87,13 @@
 - ✅ Landing pública /[slug] (7 secciones + 404 personalizada + SEO dinámico)
 - ✅ Wizard de reserva /[slug]/reservar (4 pasos + reconocimiento cliente recurrente)
 - ✅ Sistema de turnos /dashboard/turnos (timeline día + grilla semana + modales)
-- ✅ Issues #17-#29 resueltos (performance, seguridad y deuda técnica)
+- ✅ CRM de clientes /dashboard/clientes (lista + filtros + detalle + edición inline)
 
 ## Issues pendientes
 - #1 — Flujo de invitación de barberos via email (retomar con gestión de barberos)
 
 ## Próximas features
-- [ ] CRM de clientes ← SIGUIENTE
+- [ ] Gestión de barberos y servicios en dashboard ← SIGUIENTE
 - [ ] Notificaciones (WhatsApp/Twilio)
-- [ ] Gestión de barberos y servicios en dashboard
 - [ ] Bloqueo de slots (tabla blocked_slots ya existe en schema)
 - [ ] Rol barber completo (UI para vincular cuenta a registro de barbers)

--- a/actions/clients.ts
+++ b/actions/clients.ts
@@ -1,0 +1,369 @@
+"use server";
+
+import {
+  and,
+  desc,
+  eq,
+  exists,
+  gte,
+  ilike,
+  inArray,
+  lt,
+  or,
+  sql,
+} from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import {
+  appointments,
+  barbers,
+  clients,
+  profiles,
+  services,
+  tenants,
+} from "@/lib/db/schema";
+import { createClient as createSupabaseClient } from "@/lib/supabase/server";
+import type { ActionState } from "@/actions/auth";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export type ClientFilter = "all" | "new" | "vip" | "dormant" | "upcoming";
+
+export type ClientRow = {
+  id: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  visitCount: number;
+  lastVisitAt: string | null;
+  preferences: Record<string, string> | null;
+  nextAppointment: { date: string; startTime: string; serviceName: string } | null;
+};
+
+export type ClientDetail = {
+  id: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  notes: string | null;
+  visitCount: number;
+  firstVisitAt: string | null;
+  lastVisitAt: string | null;
+  preferences: Record<string, string> | null;
+  history: VisitHistoryItem[];
+};
+
+export type VisitHistoryItem = {
+  id: string;
+  date: string;
+  startTime: string;
+  serviceName: string;
+  barberName: string;
+  durationMinutes: number;
+};
+
+// ─── Auth helper ──────────────────────────────────────────────────────────────
+
+type AuthCtx = { userId: string; tenantId: string; slug: string };
+
+async function getAuth(): Promise<AuthCtx | null> {
+  const supabase = await createSupabaseClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const profile = await db.query.profiles.findFirst({
+    where: eq(profiles.id, user.id),
+    columns: { tenantId: true, role: true },
+  });
+  if (!profile?.tenantId) return null;
+
+  const tenant = await db.query.tenants.findFirst({
+    where: eq(tenants.id, profile.tenantId),
+    columns: { slug: true },
+  });
+  if (!tenant) return null;
+
+  return { userId: user.id, tenantId: profile.tenantId, slug: tenant.slug };
+}
+
+function todayISO(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+}
+
+function thirtyDaysAgoISO(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString();
+}
+
+// ─── List clients ─────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 20;
+
+export async function getClients(
+  query: string = "",
+  filter: ClientFilter = "all",
+  page: number = 1,
+): Promise<{ clients: ClientRow[]; total: number; tenantSlug: string }> {
+  const ctx = await getAuth();
+  if (!ctx) return { clients: [], total: 0, tenantSlug: "" };
+
+  const { tenantId, slug } = ctx;
+  const safePage = Math.max(1, Math.floor(page));
+  const offset = (safePage - 1) * PAGE_SIZE;
+  const today = todayISO();
+  const thirtyDaysAgo = thirtyDaysAgoISO();
+
+  // Build base WHERE conditions
+  const baseConditions = [eq(clients.tenantId, tenantId)];
+
+  if (query.trim()) {
+    const term = `%${query.trim()}%`;
+    baseConditions.push(
+      or(ilike(clients.name, term), ilike(clients.phone, term))!,
+    );
+  }
+
+  // Filter-specific conditions
+  if (filter === "new") {
+    baseConditions.push(eq(clients.visitCount, 1));
+  } else if (filter === "vip") {
+    baseConditions.push(gte(clients.visitCount, 6));
+  } else if (filter === "dormant") {
+    baseConditions.push(lt(clients.lastVisitAt, new Date(thirtyDaysAgo)));
+  } else if (filter === "upcoming") {
+    // Clients who have an upcoming appointment
+    const upcomingSubquery = db
+      .select({ one: sql<number>`1` })
+      .from(appointments)
+      .where(
+        and(
+          eq(appointments.clientId, clients.id),
+          eq(appointments.tenantId, tenantId),
+          gte(appointments.date, today),
+          inArray(appointments.status, ["pending", "confirmed"]),
+        ),
+      );
+    baseConditions.push(exists(upcomingSubquery));
+  }
+
+  const whereClause = and(...baseConditions)!;
+
+  // Count + rows in parallel
+  const [countResult, rows] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(clients)
+      .where(whereClause),
+    db
+      .select({
+        id: clients.id,
+        name: clients.name,
+        phone: clients.phone,
+        email: clients.email,
+        visitCount: clients.visitCount,
+        lastVisitAt: clients.lastVisitAt,
+        preferences: clients.preferences,
+      })
+      .from(clients)
+      .where(whereClause)
+      .orderBy(desc(clients.lastVisitAt))
+      .limit(PAGE_SIZE)
+      .offset(offset),
+  ]);
+
+  const count = countResult[0].count;
+
+  if (rows.length === 0) {
+    return { clients: [], total: count, tenantSlug: slug };
+  }
+
+  // Fetch next upcoming appointment for each client in this page
+  const clientIds = rows.map((r) => r.id);
+  const upcomingAppts = await db
+    .select({
+      clientId: appointments.clientId,
+      date: appointments.date,
+      startTime: appointments.startTime,
+      serviceName: services.name,
+    })
+    .from(appointments)
+    .innerJoin(services, eq(appointments.serviceId, services.id))
+    .where(
+      and(
+        inArray(appointments.clientId, clientIds),
+        eq(appointments.tenantId, tenantId),
+        gte(appointments.date, today),
+        inArray(appointments.status, ["pending", "confirmed"]),
+      ),
+    )
+    .orderBy(appointments.date, appointments.startTime);
+
+  // Map: first upcoming per client
+  const nextApptMap = new Map<string, { date: string; startTime: string; serviceName: string }>();
+  for (const appt of upcomingAppts) {
+    if (!nextApptMap.has(appt.clientId)) {
+      nextApptMap.set(appt.clientId, {
+        date: appt.date,
+        startTime: appt.startTime,
+        serviceName: appt.serviceName,
+      });
+    }
+  }
+
+  const result: ClientRow[] = rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    phone: r.phone,
+    email: r.email,
+    visitCount: r.visitCount,
+    lastVisitAt: r.lastVisitAt ? r.lastVisitAt.toISOString() : null,
+    preferences: r.preferences as Record<string, string> | null,
+    nextAppointment: nextApptMap.get(r.id) ?? null,
+  }));
+
+  return { clients: result, total: count, tenantSlug: slug };
+}
+
+// ─── Client detail ────────────────────────────────────────────────────────────
+
+export async function getClientDetail(
+  clientId: string,
+): Promise<ClientDetail | null> {
+  const ctx = await getAuth();
+  if (!ctx) return null;
+
+  const { tenantId } = ctx;
+
+  const [client] = await db
+    .select({
+      id: clients.id,
+      name: clients.name,
+      phone: clients.phone,
+      email: clients.email,
+      notes: clients.notes,
+      visitCount: clients.visitCount,
+      firstVisitAt: clients.firstVisitAt,
+      lastVisitAt: clients.lastVisitAt,
+      preferences: clients.preferences,
+    })
+    .from(clients)
+    .where(and(eq(clients.id, clientId), eq(clients.tenantId, tenantId)))
+    .limit(1);
+
+  if (!client) return null;
+
+  // Fetch completed appointment history
+  const history = await db
+    .select({
+      id: appointments.id,
+      date: appointments.date,
+      startTime: appointments.startTime,
+      serviceName: services.name,
+      barberName: barbers.displayName,
+      durationMinutes: services.durationMinutes,
+    })
+    .from(appointments)
+    .innerJoin(services, eq(appointments.serviceId, services.id))
+    .innerJoin(barbers, eq(appointments.barberId, barbers.id))
+    .where(
+      and(
+        eq(appointments.clientId, clientId),
+        eq(appointments.tenantId, tenantId),
+        eq(appointments.status, "completed"),
+      ),
+    )
+    .orderBy(desc(appointments.date), desc(appointments.startTime));
+
+  return {
+    id: client.id,
+    name: client.name,
+    phone: client.phone,
+    email: client.email,
+    notes: client.notes,
+    visitCount: client.visitCount,
+    firstVisitAt: client.firstVisitAt ? client.firstVisitAt.toISOString() : null,
+    lastVisitAt: client.lastVisitAt ? client.lastVisitAt.toISOString() : null,
+    preferences: client.preferences as Record<string, string> | null,
+    history,
+  };
+}
+
+// ─── Update client preferences ────────────────────────────────────────────────
+
+const preferencesSchema = z.object({
+  music: z.string().max(100).optional(),
+  drink: z.string().max(100).optional(),
+});
+
+export async function updateClientPreferences(
+  clientId: string,
+  preferences: Record<string, string>,
+): Promise<ActionState> {
+  const ctx = await getAuth();
+  if (!ctx) return { error: { _form: ["No autorizado"] } };
+
+  const { tenantId } = ctx;
+
+  const result = preferencesSchema.safeParse(preferences);
+  if (!result.success) {
+    return { error: result.error.flatten().fieldErrors };
+  }
+
+  // Single query: verify ownership + read existing preferences
+  const [existing] = await db
+    .select({ id: clients.id, preferences: clients.preferences })
+    .from(clients)
+    .where(and(eq(clients.id, clientId), eq(clients.tenantId, tenantId)))
+    .limit(1);
+
+  if (!existing) return { error: { _form: ["Cliente no encontrado"] } };
+
+  const merged = { ...(existing.preferences ?? {}), ...preferences };
+
+  await db
+    .update(clients)
+    .set({ preferences: merged })
+    .where(and(eq(clients.id, clientId), eq(clients.tenantId, tenantId)));
+
+  return { success: true };
+}
+
+// ─── Update client notes ──────────────────────────────────────────────────────
+
+const notesSchema = z.object({
+  notes: z.string().max(2000),
+});
+
+export async function updateClientNotes(
+  clientId: string,
+  notes: string,
+): Promise<ActionState> {
+  const ctx = await getAuth();
+  if (!ctx) return { error: { _form: ["No autorizado"] } };
+
+  const { tenantId } = ctx;
+
+  const result = notesSchema.safeParse({ notes });
+  if (!result.success) {
+    return { error: result.error.flatten().fieldErrors };
+  }
+
+  const [client] = await db
+    .select({ id: clients.id })
+    .from(clients)
+    .where(and(eq(clients.id, clientId), eq(clients.tenantId, tenantId)))
+    .limit(1);
+
+  if (!client) return { error: { _form: ["Cliente no encontrado"] } };
+
+  await db
+    .update(clients)
+    .set({ notes: notes.trim() || null })
+    .where(and(eq(clients.id, clientId), eq(clients.tenantId, tenantId)));
+
+  return { success: true };
+}

--- a/app/(dashboard)/dashboard/clientes/[id]/page.tsx
+++ b/app/(dashboard)/dashboard/clientes/[id]/page.tsx
@@ -1,0 +1,45 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { db } from "@/lib/db";
+import { profiles, tenants } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { getClientDetail } from "@/actions/clients";
+import { ClientDetailView } from "@/components/dashboard/clientes/client-detail-view";
+
+interface ClienteDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ClienteDetailPage({ params }: ClienteDetailPageProps) {
+  const { id } = await params;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const profile = await db.query.profiles.findFirst({
+    where: eq(profiles.id, user.id),
+    columns: { tenantId: true },
+  });
+
+  if (!profile?.tenantId) redirect("/onboarding/step-1");
+
+  const [client, tenant] = await Promise.all([
+    getClientDetail(id),
+    db.query.tenants.findFirst({
+      where: eq(tenants.id, profile.tenantId),
+      columns: { slug: true },
+    }),
+  ]);
+
+  if (!client) notFound();
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 pb-10">
+      <ClientDetailView client={client} tenantSlug={tenant?.slug ?? ""} />
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/clientes/page.tsx
+++ b/app/(dashboard)/dashboard/clientes/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { db } from "@/lib/db";
+import { profiles } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { getClients } from "@/actions/clients";
+import { ClientListView } from "@/components/dashboard/clientes/client-list-view";
+
+export const metadata = {
+  title: "Clientes — BarberSaaS",
+};
+
+export default async function ClientesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const profile = await db.query.profiles.findFirst({
+    where: eq(profiles.id, user.id),
+    columns: { tenantId: true },
+  });
+
+  if (!profile?.tenantId) redirect("/onboarding/step-1");
+
+  const { clients: initialClients, total } = await getClients("", "all", 1);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 pb-10">
+      {/* Page header */}
+      <div className="mb-6">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          CRM
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight">Clientes</h1>
+      </div>
+
+      <ClientListView
+        initialClients={initialClients}
+        initialTotal={total}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/clientes/client-card.tsx
+++ b/components/dashboard/clientes/client-card.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import Link from "next/link";
+import { Music, Coffee, Calendar, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ClientRow } from "@/actions/clients";
+import { parseDateSafe, getCategory, getInitials, CATEGORY_STYLES } from "./client-utils";
+
+interface ClientCardProps {
+  client: ClientRow;
+}
+
+function formatDate(isoString: string | null, isDateOnly = false): string {
+  if (!isoString) return "—";
+  // YYYY-MM-DD strings must use parseDateSafe to avoid UTC midnight off-by-one in UTC-3
+  const d = isDateOnly ? parseDateSafe(isoString) : new Date(isoString);
+  return d.toLocaleDateString("es-AR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function formatTime(time: string): string {
+  const [h, m] = time.split(":");
+  return `${h}:${m}`;
+}
+
+export function ClientCard({ client }: ClientCardProps) {
+  const category = getCategory(client.visitCount);
+  const hasMusic = !!client.preferences?.music;
+  const hasDrink = !!client.preferences?.drink;
+
+  return (
+    <Link
+      href={`/dashboard/clientes/${client.id}`}
+      className="group flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3.5 transition-colors hover:border-primary/30 hover:bg-card/80"
+    >
+      {/* Avatar */}
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-xs font-bold text-muted-foreground">
+        {getInitials(client.name)}
+      </div>
+
+      {/* Main info */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="truncate text-sm font-semibold">{client.name}</p>
+          <span
+            className={cn(
+              "shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+              CATEGORY_STYLES[category],
+            )}
+          >
+            {category}
+          </span>
+        </div>
+
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+          {client.phone && (
+            <p className="text-xs text-muted-foreground">{client.phone}</p>
+          )}
+
+          {/* Preference indicators */}
+          {(hasMusic || hasDrink) && (
+            <div className="flex items-center gap-1.5">
+              {hasMusic && (
+                <Music className="h-3 w-3 text-muted-foreground/60" />
+              )}
+              {hasDrink && (
+                <Coffee className="h-3 w-3 text-muted-foreground/60" />
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Next appointment or last visit */}
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+          {client.nextAppointment ? (
+            <div className="flex items-center gap-1 text-xs text-primary">
+              <Calendar className="h-3 w-3" />
+              <span>
+                {formatDate(client.nextAppointment.date, true)} · {formatTime(client.nextAppointment.startTime)} · {client.nextAppointment.serviceName}
+              </span>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground/60">
+              Última visita: {formatDate(client.lastVisitAt)}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Visit count + chevron */}
+      <div className="flex shrink-0 items-center gap-2">
+        <div className="text-right">
+          <p className="text-sm font-bold tabular-nums">{client.visitCount}</p>
+          <p className="text-[10px] text-muted-foreground/60">
+            {client.visitCount === 1 ? "visita" : "visitas"}
+          </p>
+        </div>
+        <ChevronRight className="h-4 w-4 text-muted-foreground/40 transition-transform group-hover:translate-x-0.5" />
+      </div>
+    </Link>
+  );
+}

--- a/components/dashboard/clientes/client-detail-view.tsx
+++ b/components/dashboard/clientes/client-detail-view.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Phone,
+  Calendar,
+  Clock,
+  Scissors,
+  User,
+  MessageCircle,
+  CalendarPlus,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ClientDetail } from "@/actions/clients";
+import { parseDateSafe, getCategory, getInitials, CATEGORY_STYLES } from "./client-utils";
+import { PreferencesEditor } from "./preferences-editor";
+import { NotesEditor } from "./notes-editor";
+
+interface ClientDetailViewProps {
+  client: ClientDetail;
+  tenantSlug: string;
+}
+
+function formatDate(isoString: string | null, opts?: Intl.DateTimeFormatOptions): string {
+  if (!isoString) return "—";
+  const d = new Date(isoString);
+  return d.toLocaleDateString("es-AR", opts ?? {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function formatTime(time: string): string {
+  const [h, m] = time.split(":");
+  return `${h}:${m}`;
+}
+
+export function ClientDetailView({ client, tenantSlug }: ClientDetailViewProps) {
+  const category = getCategory(client.visitCount);
+
+  const whatsappUrl = client.phone
+    ? `https://wa.me/${client.phone.replace(/\D/g, "")}`
+    : null;
+
+  const newBookingUrl = tenantSlug && client.phone
+    ? `/${tenantSlug}/reservar?phone=${encodeURIComponent(client.phone)}`
+    : tenantSlug
+      ? `/${tenantSlug}/reservar`
+      : null;
+
+  return (
+    <div>
+      {/* Back navigation */}
+      <Link
+        href="/dashboard/clientes"
+        className="mb-6 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        Volver a clientes
+      </Link>
+
+      {/* Header card */}
+      <div className="mb-4 rounded-2xl border border-border bg-card p-5">
+        <div className="flex items-start gap-4">
+          {/* Avatar */}
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-base font-bold text-muted-foreground">
+            {getInitials(client.name)}
+          </div>
+
+          {/* Info */}
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-xl font-bold tracking-tight">{client.name}</h1>
+              <span
+                className={cn(
+                  "rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+                  CATEGORY_STYLES[category],
+                )}
+              >
+                {category}
+              </span>
+            </div>
+
+            {/* Phone */}
+            {client.phone && (
+              <div className="mt-1.5 flex items-center gap-2">
+                {whatsappUrl ? (
+                  <a
+                    href={whatsappUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <Phone className="h-3.5 w-3.5" />
+                    {client.phone}
+                    <MessageCircle className="h-3.5 w-3.5 text-emerald-400" />
+                  </a>
+                ) : (
+                  <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                    <Phone className="h-3.5 w-3.5" />
+                    {client.phone}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Stats */}
+            <div className="mt-3 flex flex-wrap gap-x-5 gap-y-1">
+              <div>
+                <p className="text-xl font-bold tabular-nums">{client.visitCount}</p>
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {client.visitCount === 1 ? "Visita" : "Visitas"}
+                </p>
+              </div>
+              {client.lastVisitAt && (
+                <div>
+                  <p className="text-sm font-semibold">{formatDate(client.lastVisitAt, { day: "numeric", month: "short", year: "numeric" })}</p>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Última visita
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* New appointment CTA */}
+        {newBookingUrl && (
+          <div className="mt-4 border-t border-border pt-4">
+            <a
+              href={newBookingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-border bg-background px-4 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+            >
+              <CalendarPlus className="h-4 w-4" />
+              Nuevo turno para este cliente
+            </a>
+          </div>
+        )}
+      </div>
+
+      {/* Preferences */}
+      <div className="mb-4 rounded-xl border border-border bg-card p-4">
+        <PreferencesEditor
+          clientId={client.id}
+          initialPreferences={client.preferences}
+        />
+      </div>
+
+      {/* Notes */}
+      <div className="mb-4 rounded-xl border border-border bg-card p-4">
+        <NotesEditor clientId={client.id} initialNotes={client.notes} />
+      </div>
+
+      {/* Visit history */}
+      <div className="rounded-xl border border-border bg-card p-4">
+        <div className="mb-4">
+          <h3 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Historial
+          </h3>
+          <p className="text-base font-bold tracking-tight">Visitas completadas</p>
+        </div>
+
+        {client.history.length === 0 ? (
+          <div className="py-8 text-center">
+            <Calendar className="mx-auto h-6 w-6 text-muted-foreground/30" />
+            <p className="mt-2 text-sm text-muted-foreground">
+              Sin visitas completadas aún
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-0 divide-y divide-border">
+            {client.history.map((visit) => (
+              <VisitRow key={visit.id} visit={visit} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function VisitRow({ visit }: { visit: ClientDetail["history"][number] }) {
+  // visit.date is YYYY-MM-DD — use parseDateSafe to avoid UTC midnight off-by-one in UTC-3
+  const d = parseDateSafe(visit.date);
+  const dateStr = d.toLocaleDateString("es-AR", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <div className="flex items-center gap-3 py-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/8">
+        <Calendar className="h-4 w-4 text-primary/70" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+          <p className="text-sm font-medium capitalize">{dateStr}</p>
+          <span className="text-xs text-muted-foreground/60">·</span>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Clock className="h-3 w-3" />
+            {visit.startTime.slice(0, 5)}
+          </div>
+        </div>
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5">
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Scissors className="h-3 w-3" />
+            {visit.serviceName}
+          </div>
+          <span className="text-xs text-muted-foreground/40">·</span>
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <User className="h-3 w-3" />
+            {visit.barberName}
+          </div>
+          <span className="text-xs text-muted-foreground/40">·</span>
+          <p className="text-xs text-muted-foreground">{visit.durationMinutes} min</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/clientes/client-filters.tsx
+++ b/components/dashboard/clientes/client-filters.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { ClientFilter } from "@/actions/clients";
+
+const FILTERS: { value: ClientFilter; label: string }[] = [
+  { value: "all", label: "Todos" },
+  { value: "new", label: "Nuevo" },
+  { value: "vip", label: "VIP" },
+  { value: "dormant", label: "Sin turno 30+ días" },
+  { value: "upcoming", label: "Turno próximo" },
+];
+
+interface ClientFiltersProps {
+  active: ClientFilter;
+  onChange: (filter: ClientFilter) => void;
+}
+
+export function ClientFilters({ active, onChange }: ClientFiltersProps) {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-none">
+      {FILTERS.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => onChange(value)}
+          className={cn(
+            "shrink-0 rounded-full border px-3.5 py-1.5 text-xs font-medium transition-colors",
+            active === value
+              ? "border-primary bg-primary/10 text-primary"
+              : "border-border bg-card text-muted-foreground hover:border-primary/30 hover:text-foreground",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/dashboard/clientes/client-list-view.tsx
+++ b/components/dashboard/clientes/client-list-view.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useTransition, useCallback, useRef } from "react";
+import { Users } from "lucide-react";
+import { getClients } from "@/actions/clients";
+import type { ClientRow, ClientFilter } from "@/actions/clients";
+import { ClientCard } from "./client-card";
+import { ClientSearch } from "./client-search";
+import { ClientFilters } from "./client-filters";
+
+interface ClientListViewProps {
+  initialClients: ClientRow[];
+  initialTotal: number;
+}
+
+export function ClientListView({
+  initialClients,
+  initialTotal,
+}: ClientListViewProps) {
+  const [clients, setClients] = useState<ClientRow[]>(initialClients);
+  const [total, setTotal] = useState(initialTotal);
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<ClientFilter>("all");
+  const [page, setPage] = useState(1);
+  const [isPending, startTransition] = useTransition();
+
+  // Ref to avoid stale closure in debounce
+  const filterRef = useRef(filter);
+  const queryRef = useRef(query);
+  filterRef.current = filter;
+  queryRef.current = query;
+
+  const fetchClients = useCallback(
+    (q: string, f: ClientFilter, p: number, append = false) => {
+      startTransition(async () => {
+        const result = await getClients(q, f, p);
+        setTotal(result.total);
+        if (append) {
+          setClients((prev) => [...prev, ...result.clients]);
+        } else {
+          setClients(result.clients);
+        }
+      });
+    },
+    [],
+  );
+
+  const handleSearch = useCallback(
+    (q: string) => {
+      setQuery(q);
+      setPage(1);
+      fetchClients(q, filterRef.current, 1);
+    },
+    [fetchClients],
+  );
+
+  const handleFilter = useCallback(
+    (f: ClientFilter) => {
+      setFilter(f);
+      setPage(1);
+      fetchClients(queryRef.current, f, 1);
+    },
+    [fetchClients],
+  );
+
+  const handleLoadMore = useCallback(() => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchClients(query, filter, nextPage, true);
+  }, [page, query, filter, fetchClients]);
+
+  const hasMore = clients.length < total;
+
+  return (
+    <div>
+      {/* Search */}
+      <div className="mb-4">
+        <ClientSearch onSearch={handleSearch} />
+      </div>
+
+      {/* Filters */}
+      <div className="mb-5">
+        <ClientFilters active={filter} onChange={handleFilter} />
+      </div>
+
+      {/* Results count */}
+      <div className="mb-4 flex items-center gap-2">
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{total}</span>{" "}
+          {total === 1 ? "cliente" : "clientes"}
+          {query && (
+            <span>
+              {" "}
+              para <span className="font-medium text-foreground">"{query}"</span>
+            </span>
+          )}
+        </p>
+      </div>
+
+      {/* Loading overlay indicator */}
+      {isPending && clients.length > 0 && (
+        <div className="mb-3 h-0.5 w-full overflow-hidden rounded-full bg-border">
+          <div className="h-full w-1/2 animate-pulse rounded-full bg-primary/40" />
+        </div>
+      )}
+
+      {/* Client list */}
+      {clients.length === 0 ? (
+        <EmptyState query={query} filter={filter} isPending={isPending} />
+      ) : (
+        <>
+          <div className="space-y-2">
+            {clients.map((client) => (
+              <ClientCard key={client.id} client={client} />
+            ))}
+          </div>
+
+          {hasMore && (
+            <div className="mt-6 flex justify-center">
+              <button
+                onClick={handleLoadMore}
+                disabled={isPending}
+                className="rounded-xl border border-border bg-card px-6 py-2.5 text-sm font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground disabled:opacity-50"
+              >
+                {isPending ? "Cargando..." : `Ver más (${total - clients.length} restantes)`}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({
+  query,
+  filter,
+  isPending,
+}: {
+  query: string;
+  filter: ClientFilter;
+  isPending: boolean;
+}) {
+  if (isPending) {
+    return (
+      <div className="space-y-2">
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded-xl border border-border bg-card/50"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-card/50 px-4 py-12 text-center">
+      <Users className="mx-auto h-8 w-8 text-muted-foreground/30" />
+      <p className="mt-3 text-sm font-medium text-muted-foreground">
+        {query
+          ? `Sin resultados para "${query}"`
+          : filter !== "all"
+            ? "No hay clientes en esta categoría"
+            : "Aún no hay clientes"}
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground/60">
+        {query
+          ? "Probá con otro nombre o teléfono"
+          : filter !== "all"
+            ? "Probá con otro filtro"
+            : "Los clientes aparecerán acá cuando reserven turnos"}
+      </p>
+    </div>
+  );
+}

--- a/components/dashboard/clientes/client-search.tsx
+++ b/components/dashboard/clientes/client-search.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Search, X } from "lucide-react";
+
+interface ClientSearchProps {
+  onSearch: (query: string) => void;
+}
+
+export function ClientSearch({ onSearch }: ClientSearchProps) {
+  const [value, setValue] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      onSearch(value);
+    }, 300);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [value, onSearch]);
+
+  return (
+    <div className="relative">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Buscar por nombre o teléfono..."
+        className="h-10 w-full rounded-xl border border-border bg-card pl-9 pr-9 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors focus:border-primary/40 focus:outline-none"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => setValue("")}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/clientes/client-utils.ts
+++ b/components/dashboard/clientes/client-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Parsea una fecha YYYY-MM-DD sin interpretar como UTC midnight.
+ * new Date("2024-03-15") en UTC-3 daría "14 mar" — incorrecto.
+ * Añadir "T12:00:00" fuerza el mediodía local y evita el off-by-one.
+ */
+export function parseDateSafe(dateStr: string): Date {
+  return new Date(`${dateStr}T12:00:00`);
+}
+
+export type Category = "Nuevo" | "Regular" | "VIP";
+
+export function getCategory(visitCount: number): Category {
+  if (visitCount <= 1) return "Nuevo";
+  if (visitCount < 6) return "Regular";
+  return "VIP";
+}
+
+export function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0] ?? "")
+    .join("")
+    .toUpperCase();
+}
+
+export const CATEGORY_STYLES: Record<Category, string> = {
+  Nuevo: "border-sky-500/30 bg-sky-500/10 text-sky-400",
+  Regular: "border-amber-500/30 bg-amber-500/10 text-amber-400",
+  VIP: "border-emerald-500/30 bg-emerald-500/10 text-emerald-400",
+};

--- a/components/dashboard/clientes/notes-editor.tsx
+++ b/components/dashboard/clientes/notes-editor.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Check, Loader2 } from "lucide-react";
+import { updateClientNotes } from "@/actions/clients";
+
+interface NotesEditorProps {
+  clientId: string;
+  initialNotes: string | null;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+export function NotesEditor({ clientId, initialNotes }: NotesEditorProps) {
+  const [notes, setNotes] = useState(initialNotes ?? "");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleBlur = async () => {
+    setSaveState("saving");
+    try {
+      const result = await updateClientNotes(clientId, notes);
+      setSaveState(result.success ? "saved" : "error");
+    } catch {
+      setSaveState("error");
+    } finally {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => setSaveState("idle"), 2000);
+    }
+  };
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Notas del barbero
+        </h3>
+        <SaveIndicator state={saveState} />
+      </div>
+
+      <textarea
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        onBlur={handleBlur}
+        placeholder="Anotaciones internas sobre este cliente…"
+        maxLength={2000}
+        rows={4}
+        className="w-full resize-none rounded-xl border border-border bg-card px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground/50 transition-colors focus:border-primary/40 focus:outline-none"
+      />
+    </div>
+  );
+}
+
+function SaveIndicator({ state }: { state: SaveState }) {
+  if (state === "idle") return null;
+  if (state === "saving") {
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        <span>Guardando…</span>
+      </div>
+    );
+  }
+  if (state === "saved") {
+    return (
+      <div className="flex items-center gap-1 text-xs text-emerald-400">
+        <Check className="h-3 w-3" />
+        <span>Guardado</span>
+      </div>
+    );
+  }
+  return <span className="text-xs text-destructive">Error al guardar</span>;
+}

--- a/components/dashboard/clientes/preferences-editor.tsx
+++ b/components/dashboard/clientes/preferences-editor.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { Music, Coffee, Check, Loader2 } from "lucide-react";
+import { updateClientPreferences } from "@/actions/clients";
+
+interface PreferencesEditorProps {
+  clientId: string;
+  initialPreferences: Record<string, string> | null;
+}
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+export function PreferencesEditor({
+  clientId,
+  initialPreferences,
+}: PreferencesEditorProps) {
+  const [music, setMusic] = useState(initialPreferences?.music ?? "");
+  const [drink, setDrink] = useState(initialPreferences?.drink ?? "");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const save = async (updated: Record<string, string>) => {
+    setSaveState("saving");
+    try {
+      const result = await updateClientPreferences(clientId, updated);
+      setSaveState(result.success ? "saved" : "error");
+    } catch {
+      setSaveState("error");
+    } finally {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(() => setSaveState("idle"), 2000);
+    }
+  };
+
+  const handleMusicBlur = () => {
+    save({ music, drink });
+  };
+
+  const handleDrinkBlur = () => {
+    save({ music, drink });
+  };
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          Preferencias
+        </h3>
+        <SaveIndicator state={saveState} />
+      </div>
+
+      <div className="space-y-3">
+        <div className="relative">
+          <Music className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={music}
+            onChange={(e) => setMusic(e.target.value)}
+            onBlur={handleMusicBlur}
+            placeholder="Música preferida…"
+            maxLength={100}
+            className="h-10 w-full rounded-xl border border-border bg-card pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/50 transition-colors focus:border-primary/40 focus:outline-none"
+          />
+        </div>
+
+        <div className="relative">
+          <Coffee className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={drink}
+            onChange={(e) => setDrink(e.target.value)}
+            onBlur={handleDrinkBlur}
+            placeholder="Bebida preferida…"
+            maxLength={100}
+            className="h-10 w-full rounded-xl border border-border bg-card pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground/50 transition-colors focus:border-primary/40 focus:outline-none"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SaveIndicator({ state }: { state: SaveState }) {
+  if (state === "idle") return null;
+  if (state === "saving") {
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        <span>Guardando…</span>
+      </div>
+    );
+  }
+  if (state === "saved") {
+    return (
+      <div className="flex items-center gap-1 text-xs text-emerald-400">
+        <Check className="h-3 w-3" />
+        <span>Guardado</span>
+      </div>
+    );
+  }
+  return (
+    <span className="text-xs text-destructive">Error al guardar</span>
+  );
+}

--- a/components/dashboard/top-nav.tsx
+++ b/components/dashboard/top-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { Scissors, LogOut, ExternalLink, LayoutDashboard, CalendarClock } from "lucide-react";
+import { Scissors, LogOut, ExternalLink, LayoutDashboard, CalendarClock, Users } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { logout } from "@/actions/auth";
@@ -15,6 +15,7 @@ interface DashboardTopNavProps {
 const NAV_ITEMS = [
   { href: "/dashboard", label: "Resumen", icon: LayoutDashboard },
   { href: "/dashboard/turnos", label: "Turnos", icon: CalendarClock },
+  { href: "/dashboard/clientes", label: "Clientes", icon: Users },
 ];
 
 export function DashboardTopNav({


### PR DESCRIPTION
## feat: CRM de clientes /dashboard/clientes

### Qué incluye
- Lista de clientes con buscador (debounce 300ms) y filtros rápidos
  (Nuevo, VIP, Sin turno 30+ días, Con turno próximo)
- Cards con avatar, badge de categoría, preferencias y próximo turno
- Página de detalle con preferencias y notas editables (onBlur save)
- Historial de visitas completadas con servicio y barbero
- Link directo a WhatsApp y CTA "Nuevo turno"
- Autorización por rol — owner y barber con acceso completo

### Fixes aplicados durante el review
- Timezone bug en fechas de appointment (parseDateSafe en client-utils.ts)
- UPDATE con tenantId en WHERE para defensa en profundidad
- parseDateSafe movida fuera de "use server" — build error corregido
- PAGE_SIZE como const privado (Next.js prohíbe exports no-async desde "use server")
- Utilidades compartidas extraídas a client-utils.ts
- Promise.all para count + rows en getClients